### PR TITLE
Add GitHub Action to auto-close issues on PR merge

### DIFF
--- a/.github/workflows/close-issues-on-merge.yml
+++ b/.github/workflows/close-issues-on-merge.yml
@@ -1,0 +1,64 @@
+name: Close Issues on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [netlify]
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close linked issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prBody = context.payload.pull_request.body || '';
+            const prNumber = context.payload.pull_request.number;
+
+            // Match "Closes #X", "closes #X", "Fixes #X", "fixes #X", "Resolves #X", "resolves #X"
+            const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*#(\d+)/gi;
+            const matches = [...prBody.matchAll(regex)];
+
+            if (matches.length === 0) {
+              console.log('No issue references found in PR body');
+              return;
+            }
+
+            for (const match of matches) {
+              const issueNumber = parseInt(match[1], 10);
+              try {
+                // Check if issue exists and is open
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber
+                });
+
+                if (issue.state === 'open' && !issue.pull_request) {
+                  await github.rest.issues.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    state: 'closed',
+                    state_reason: 'completed'
+                  });
+                  console.log(`Closed issue #${issueNumber}`);
+
+                  // Add a comment linking to the PR
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    body: `Closed via #${prNumber}`
+                  });
+                } else {
+                  console.log(`Issue #${issueNumber} is already closed or is a PR`);
+                }
+              } catch (error) {
+                console.log(`Could not process issue #${issueNumber}: ${error.message}`);
+              }
+            }


### PR DESCRIPTION
## Summary

Since `main` is the default branch (to keep forks clean), PRs merged to `netlify` don't trigger GitHub's auto-close behavior. This action fills that gap by:

- Triggering when a PR is merged to `netlify`
- Parsing the PR body for "Closes #X", "Fixes #X", "Resolves #X" patterns
- Closing the referenced issues and adding a comment linking to the PR

## Type of Change

- [x] Site improvement (layout, styling, functionality)

## Checklist

- [x] Tested locally with `bundle exec jekyll serve`
- [x] Site builds without errors (`bundle exec jekyll build`)
- [ ] Screenshots attached (for visual changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)