### PR TITLE
Use GraphQL for issue auto-close instead of regex

### DIFF
--- a/.github/workflows/close-issues-on-merge.yml
+++ b/.github/workflows/close-issues-on-merge.yml
@@ -16,49 +16,59 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const prBody = context.payload.pull_request.body || '';
             const prNumber = context.payload.pull_request.number;
 
-            // Match "Closes #X", "closes #X", "Fixes #X", "fixes #X", "Resolves #X", "resolves #X"
-            const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*#(\d+)/gi;
-            const matches = [...prBody.matchAll(regex)];
+            // Use GraphQL to get issues linked via GitHub's "linked issues" feature
+            const query = `
+              query($owner: String!, $repo: String!, $prNumber: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $prNumber) {
+                    closingIssuesReferences(first: 10) {
+                      nodes {
+                        number
+                        state
+                      }
+                    }
+                  }
+                }
+              }
+            `;
 
-            if (matches.length === 0) {
-              console.log('No issue references found in PR body');
+            const result = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              prNumber: prNumber
+            });
+
+            const linkedIssues = result.repository.pullRequest.closingIssuesReferences.nodes;
+
+            if (linkedIssues.length === 0) {
+              console.log('No linked issues found');
               return;
             }
 
-            for (const match of matches) {
-              const issueNumber = parseInt(match[1], 10);
-              try {
-                // Check if issue exists and is open
-                const { data: issue } = await github.rest.issues.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issueNumber
-                });
-
-                if (issue.state === 'open' && !issue.pull_request) {
+            for (const issue of linkedIssues) {
+              if (issue.state === 'OPEN') {
+                try {
                   await github.rest.issues.update({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    issue_number: issueNumber,
+                    issue_number: issue.number,
                     state: 'closed',
                     state_reason: 'completed'
                   });
-                  console.log(`Closed issue #${issueNumber}`);
+                  console.log(`Closed issue #${issue.number}`);
 
-                  // Add a comment linking to the PR
                   await github.rest.issues.createComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    issue_number: issueNumber,
+                    issue_number: issue.number,
                     body: `Closed via #${prNumber}`
                   });
-                } else {
-                  console.log(`Issue #${issueNumber} is already closed or is a PR`);
+                } catch (error) {
+                  console.log(`Could not close issue #${issue.number}: ${error.message}`);
                 }
-              } catch (error) {
-                console.log(`Could not process issue #${issueNumber}: ${error.message}`);
+              } else {
+                console.log(`Issue #${issue.number} already closed`);
               }
             }


### PR DESCRIPTION
## Summary

Replace brittle regex parsing with GitHub's GraphQL `closingIssuesReferences` API. Now uses GitHub's native linked issues feature instead of parsing PR body text.

## Type of Change

- [ ] Content fix (typo, broken link, factual error)
- [ ] New post
- [x] Site improvement (layout, styling, functionality)
- [ ] Other

## Checklist

- [x] PR targets `netlify` branch (not `main`)
- [ ] Tested locally with `bundle exec jekyll serve`
- [x] Site builds without errors (`bundle exec jekyll build`)
- [ ] Screenshots attached (for visual changes)