### PR TITLE
Add paper posts for IROS 2023, Humanoids 2023, and 3DV 2026

### DIFF
--- a/_posts/2023-10-01-uncertain-regions.md
+++ b/_posts/2023-10-01-uncertain-regions.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: Shape Completion with Prediction of Uncertain Regions
+abstract: We propose two novel methods for predicting uncertain geometric regions as straightforward extensions of any method for predicting local spatial occupancy. Our evaluation demonstrates that avoiding predicted uncertain regions improves grasp quality in robotic manipulation.
+category: paper
+tags: [shape-completion, uncertainty, point-clouds, robotics, grasping]
+image: https://hummat.github.io/2023-iros-uncertain/static/images/icon.png
+gh-page: https://hummat.github.io/2023-iros-uncertain/
+time: 1
+words: 50
+---

--- a/_posts/2023-10-01-uncertain-regions.md
+++ b/_posts/2023-10-01-uncertain-regions.md
@@ -4,7 +4,7 @@ title: Shape Completion with Prediction of Uncertain Regions
 abstract: We propose two novel methods for predicting uncertain geometric regions as straightforward extensions of any method for predicting local spatial occupancy. Our evaluation demonstrates that avoiding predicted uncertain regions improves grasp quality in robotic manipulation.
 category: paper
 tags: [shape-completion, uncertainty, point-clouds, robotics, grasping]
-image: https://hummat.github.io/2023-iros-uncertain/static/images/icon.png
+image: https://hummat.github.io/2023-iros-uncertain/static/images/uncertain_region.png
 gh-page: https://hummat.github.io/2023-iros-uncertain/
 time: 1
 words: 50

--- a/_posts/2023-12-01-humanoids-grasping.md
+++ b/_posts/2023-12-01-humanoids-grasping.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: Combining Shape Completion and Grasp Prediction for Fast and Versatile Grasping with a Multi-Fingered Hand
+abstract: We propose a pipeline combining shape completion from single depth images with grasp prediction for multi-fingered hands. Our system reconstructs object geometry and generates 1000 grasp candidates in approximately one second, enabling fast and versatile grasping of unknown objects.
+category: paper
+tags: [shape-completion, grasping, robotics, point-clouds, depth]
+image: https://assets.hummat.com/images/humanoids23-shape-completion.jpg
+gh-page: https://aidx-lab.org/grasping/humanoids23
+time: 1
+words: 50
+---

--- a/_posts/2026-03-01-genz.md
+++ b/_posts/2026-03-01-genz.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: Evaluating Latent Generative Paradigms for High-Fidelity 3D Shape Completion
+abstract: We compare diffusion models and autoregressive transformers for reconstructing complete 3D shapes from partial depth images, showing that a diffusion model with continuous latents outperforms both discriminative models and autoregressive approaches, achieving state-of-the-art performance on multi-modal shape completion.
+category: paper
+tags: [shape-completion, diffusion, transformer, point-clouds, depth]
+image: https://hummat.github.io/2026-3dv-genz/static/images/icon.png
+gh-page: https://hummat.github.io/2026-3dv-genz/
+time: 1
+words: 50
+---

--- a/_posts/2026-03-01-genz.md
+++ b/_posts/2026-03-01-genz.md
@@ -4,7 +4,7 @@ title: Evaluating Latent Generative Paradigms for High-Fidelity 3D Shape Complet
 abstract: We compare diffusion models and autoregressive transformers for reconstructing complete 3D shapes from partial depth images, showing that a diffusion model with continuous latents outperforms both discriminative models and autoregressive approaches, achieving state-of-the-art performance on multi-modal shape completion.
 category: paper
 tags: [shape-completion, diffusion, transformer, point-clouds, depth]
-image: https://hummat.github.io/2026-3dv-genz/static/images/icon.png
+image: https://hummat.github.io/2026-3dv-genz/static/images/ycb/mokka_gen.png
 gh-page: https://hummat.github.io/2026-3dv-genz/
 time: 1
 words: 50


### PR DESCRIPTION
## Summary

Add three new paper-category posts linking to existing project pages:

- **IROS 2023**: Shape Completion with Prediction of Uncertain Regions
- **Humanoids 2023**: Combining Shape Completion and Grasp Prediction for Fast and Versatile Grasping
- **3DV 2026**: Evaluating Latent Generative Paradigms for High-Fidelity 3D Shape Completion

Closes: #38

## Type of Change

- [x] New post

## Checklist

- [x] PR targets `netlify` branch (not `main`)
- [ ] Tested locally with `bundle exec jekyll serve`
- [ ] Site builds without errors (`bundle exec jekyll build`)
- [ ] Screenshots attached (for visual changes)

## Test plan

- [ ] Verify posts appear in listings with correct thumbnails
- [ ] Verify clicking posts redirects to gh-page URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)