### PR TITLE
Add PaperPipe repository post

### DIFF
--- a/_posts/2025-12-23-paperpipe.md
+++ b/_posts/2025-12-23-paperpipe.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: PaperPipe
+abstract: A CLI tool that maintains a local paper database with PDFs, LaTeX source, extracted equations, and coding-oriented summaries. Integrates with coding agents (Claude Code, Codex, Gemini CLI) so they can ground their responses in actual paper content rather than hallucinating implementation details.
+category: repository
+tags: [research, papers, llm, cli, python, code, github]
+image: https://repository-images.githubusercontent.com/1120503046/8ba4e2ed-30ef-4d0d-996f-68a48962cb9b
+gh-page: https://hummat.github.io/paperpipe
+time: 3
+words: 600
+---


### PR DESCRIPTION
## Summary
- Adds repository showcase post for PaperPipe CLI tool
- Links to project page via `gh-page` field

## Type
- [x] New content (post, page)

## Checklist
- [x] Front matter complete
- [x] Category correct (`repository`)
- [x] Branch from `netlify`, PR to `netlify`

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)