### PR TITLE
Fix fetch reliability and URL validation in publications page

### DIFF
--- a/publications.md
+++ b/publications.md
@@ -44,7 +44,7 @@ title: Publications
 
   function isHttpUrl(url) {
     try {
-      var parsed = new URL(url, 'https://placeholder.invalid');
+      var parsed = new URL(url);
       return parsed.protocol === 'http:' || parsed.protocol === 'https:';
     } catch (e) {
       return false;
@@ -260,12 +260,14 @@ title: Publications
     }
 
     function fetchWithRetry(attempt) {
-      var controller = new AbortController();
-      var timeoutId = setTimeout(function() { controller.abort(); }, 15000);
+      var controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+      var timeoutId = controller
+        ? setTimeout(function() { controller.abort(); }, 15000)
+        : null;
 
-      return fetch(apiUrl, { signal: controller.signal })
+      return fetch(apiUrl, controller ? { signal: controller.signal } : {})
         .then(function(response) {
-          clearTimeout(timeoutId);
+          if (timeoutId) clearTimeout(timeoutId);
           if (response.status === 429 && attempt < MAX_RETRIES) {
             var retryAfter = parseInt(response.headers.get('Retry-After'), 10);
             var delay = (retryAfter && retryAfter > 0)
@@ -287,7 +289,7 @@ title: Publications
           });
         })
         .catch(function(err) {
-          clearTimeout(timeoutId);
+          if (timeoutId) clearTimeout(timeoutId);
           handleFetchFailure(err);
         });
     }

--- a/publications.md
+++ b/publications.md
@@ -261,13 +261,20 @@ title: Publications
 
     function fetchWithRetry(attempt) {
       var controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
-      var timeoutId = controller
-        ? setTimeout(function() { controller.abort(); }, 15000)
-        : null;
+      var timeoutId;
 
-      return fetch(apiUrl, controller ? { signal: controller.signal } : {})
+      var fetchPromise = fetch(apiUrl, controller ? { signal: controller.signal } : {});
+
+      var timeoutPromise = new Promise(function(_, reject) {
+        timeoutId = setTimeout(function() {
+          if (controller) controller.abort();
+          reject(new Error('Request timed out'));
+        }, 15000);
+      });
+
+      return Promise.race([fetchPromise, timeoutPromise])
         .then(function(response) {
-          if (timeoutId) clearTimeout(timeoutId);
+          clearTimeout(timeoutId);
           if (response.status === 429 && attempt < MAX_RETRIES) {
             var retryAfter = parseInt(response.headers.get('Retry-After'), 10);
             var delay = (retryAfter && retryAfter > 0)
@@ -289,7 +296,7 @@ title: Publications
           });
         })
         .catch(function(err) {
-          if (timeoutId) clearTimeout(timeoutId);
+          clearTimeout(timeoutId);
           handleFetchFailure(err);
         });
     }

--- a/publications.md
+++ b/publications.md
@@ -42,6 +42,15 @@ title: Publications
     return cached && (Date.now() - cached.timestamp) < CACHE_TTL;
   }
 
+  function isHttpUrl(url) {
+    try {
+      var parsed = new URL(url, 'https://placeholder.invalid');
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch (e) {
+      return false;
+    }
+  }
+
   function updateProfileLink(authorUrl) {
     var link = document.getElementById('semantic-scholar-profile-link');
     if (!link || !authorUrl) {
@@ -52,6 +61,7 @@ title: Publications
     if (href.indexOf('http') !== 0) {
       href = 'https://www.semanticscholar.org' + href;
     }
+    if (!isHttpUrl(href)) return;
     link.href = href + (href.indexOf('?') === -1 ? '?utm_source=api' : '&utm_source=api');
   }
 
@@ -191,7 +201,7 @@ title: Publications
       titleContainer.className = 'publication-title';
 
       var titleText = paper.title || 'Untitled';
-      if (paper.url) {
+      if (paper.url && isHttpUrl(paper.url)) {
         var link = document.createElement('a');
         link.href = paper.url + (paper.url.indexOf('?') === -1 ? '?utm_source=api' : '&utm_source=api');
         link.textContent = titleText;
@@ -250,8 +260,12 @@ title: Publications
     }
 
     function fetchWithRetry(attempt) {
-      fetch(apiUrl)
+      var controller = new AbortController();
+      var timeoutId = setTimeout(function() { controller.abort(); }, 15000);
+
+      return fetch(apiUrl, { signal: controller.signal })
         .then(function(response) {
+          clearTimeout(timeoutId);
           if (response.status === 429 && attempt < MAX_RETRIES) {
             var retryAfter = parseInt(response.headers.get('Retry-After'), 10);
             var delay = (retryAfter && retryAfter > 0)
@@ -273,6 +287,7 @@ title: Publications
           });
         })
         .catch(function(err) {
+          clearTimeout(timeoutId);
           handleFetchFailure(err);
         });
     }


### PR DESCRIPTION
## Summary

- **Fix broken promise chain (#62):** Add `return` before `fetch()` in `fetchWithRetry` so retry logic propagates correctly
- **Add 15s fetch timeout (#68):** Wrap `fetch()` with `AbortController` to prevent indefinite hangs when the Semantic Scholar API is unresponsive
- **URL protocol validation (#56):** Add `isHttpUrl()` helper that validates URLs from API responses before assigning to `href`, preventing XSS via `javascript:` protocol URLs

Closes #62, #68, #56

## Test plan

- [x] `bundle exec jekyll build` — no build errors
- [x] `bundle exec jekyll serve` → publications load normally at `/publications/`
- [x] No JS console errors (verified via Playwright)
- [ ] Retry button still works (test by temporarily setting a bad author ID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)