### PR TITLE
Add unsafe-eval to CSP for Plotly WebGL rendering

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   for = "/*"
 
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://code.jquery.com https://cdn.plot.ly https://cdnjs.cloudflare.com https://www.googletagmanager.com https://*.disqus.com https://*.disquscdn.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.semanticscholar.org https://assets.hummat.com https://www.google-analytics.com https://region1.google-analytics.com https://*.disqus.com https://*.disquscdn.com; frame-src 'self' https://assets.hummat.com https://disqus.com https://*.disqus.com https://*.disquscdn.com; font-src 'self' data: https://cdnjs.cloudflare.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://code.jquery.com https://cdn.plot.ly https://cdnjs.cloudflare.com https://www.googletagmanager.com https://*.disqus.com https://*.disquscdn.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.semanticscholar.org https://assets.hummat.com https://www.google-analytics.com https://region1.google-analytics.com https://*.disqus.com https://*.disquscdn.com; frame-src 'self' https://assets.hummat.com https://disqus.com https://*.disqus.com https://*.disquscdn.com; font-src 'self' data: https://cdnjs.cloudflare.com; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests"
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"


### PR DESCRIPTION
## Summary

- Add `'unsafe-eval'` to `script-src` in `netlify.toml` so Plotly's regl shader compilation works
- Fixes broken `scattergl` figure on implicit-function-learning and EvalErrors on all pages with R2-hosted Plotly figures

Closes #75

## Test plan

- [ ] Verify `/learning/2022/02/23/implicit-function-learning` — "Image" figure should render instead of showing "WebGL is not supported"
- [ ] Verify `/learning/2021/02/04/learning-from-projections` — no `EvalError` in console
- [ ] Check other Plotly posts for console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)