### PR TITLE
Fix Lighthouse performance and best practices scores

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ tagline: Blog of Matthias Humt, PhD student, Researcher, Visualizer.
 description: PhD student at TU Munich<br> Researcher with the German Aerospace Center (DLR)<br> Visualization Aficionado
 
 # URL of your avatar or profile pic (you could use your GitHub profile pic)
-avatar: https://github.com/hummat.png
+avatar: https://avatars.githubusercontent.com/u/22399283?v=4
 defaults:
   - scope:
       path: ""

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,7 @@
       <div class="container">
         <div class="masthead clearfix">
           <a href="{{ site.baseurl }}/" class="site-avatar"
-            ><img src="{{ site.avatar }}" alt="avatar"
+            ><img src="{{ site.avatar }}" alt="avatar" width="70" height="70"
           /></a>
 
           <div class="site-info">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -25,7 +25,8 @@ layout: default
       <div
         class="{% if post.circular %}{{ 'thumbnail circular' }}{% else %}{{ 'thumbnail' }}{% endif %}"
       >
-        <img src="{{ post.image }}" alt="thumbnail" />
+        {% assign lazy = false %}{% if forloop.index > 2 %}{% assign lazy = true %}{% endif %}
+        <img src="{{ post.image }}" alt="thumbnail" {% if lazy %}loading="lazy" {% endif %} />
       </div>
       <div class="narrow-description">
         <h2>{{ post.title }}</h2>


### PR DESCRIPTION
## Summary
- **Avatar URL**: Point directly to `avatars.githubusercontent.com` CDN, skipping the `github.com/user.png` → CDN redirect that caused third-party cookie errors (`_gh_sess`, `_octo`, `logged_in`)
- **Avatar dimensions**: Add `width="70" height="70"` matching `.site-avatar` CSS to prevent CLS
- **Thumbnail lazy loading**: First 2 thumbnails eager (above-the-fold), remaining ~23 get `loading="lazy"` to reduce initial network requests

## Lighthouse results (local)
| Metric | Desktop before→after | Mobile before→after |
|--------|---------------------|---------------------|
| Performance | 79→88 | 75→99 |
| CLS | >0→0 | >0→0 |
| Best practices | 78→74* | 78→75* |

*Best practices dip is from pre-existing Wikimedia third-party cookies (footer icons) and a draft post 404 — unrelated to these changes. On production, the avatar redirect fix should improve best practices by eliminating 3 GitHub cookie errors.

## Test plan
- [x] `bundle exec jekyll build` — succeeds
- [x] Visual check — avatar renders, thumbnails display correctly
- [x] Lighthouse audit — performance improved, CLS eliminated
- [x] Browser console — zero errors locally
- [x] First 2 thumbnails eager, rest lazy (verified in `_site/index.html`)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)