### PR TITLE
Use semantic <time> elements for dates

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,7 +6,9 @@ layout: default
   {% for post in site.posts %}
   <article class="post">
     <div class="metadata">
-      <div class="date">{{ post.date | date: "%B %e, %Y" }}</div>
+      <time class="date" datetime="{{ post.date | date_to_xmlschema }}"
+        >{{ post.date | date: "%B %e, %Y" }}</time
+      >
       <div class="tags">
         {% if post.category != empty %}
         <div class="tag category">{{ post.category }}</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,8 +5,13 @@ layout: default
 <article class="post">
   <div class="entry">{{ content }}</div>
   <div class="date noprint">
-    {% if page.update %} Last updated on {{ page.update | date: "%B %e, %Y" }} {% else %} Written on
-    {{ page.date | date: "%B %e, %Y" }} {% endif %}
+    {% if page.update %} Last updated on
+    <time datetime="{{ page.update | date_to_xmlschema }}"
+      >{{ page.update | date: "%B %e, %Y" }}</time
+    >
+    {% else %} Written on
+    <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %e, %Y" }}</time>
+    {% endif %}
   </div>
   {% include disqus.html %}
 </article>


### PR DESCRIPTION
## Summary

Replace `<div>` / plain text date rendering with semantic `<time datetime="...">` elements in `home.html` and `post.html` layouts. The `datetime` attribute uses Jekyll's `date_to_xmlschema` filter for ISO 8601 machine-readable dates.

Closes: #78

Also closes #79 (robots.txt already exists with proper User-agent rules and sitemap reference).

## Type of Change

- [x] Site improvement (layout, styling, functionality)

## Checklist

- [x] PR targets `netlify` branch (not `main`)
- [x] Tested locally with `bundle exec jekyll serve`
- [x] Site builds without errors (`bundle exec jekyll build`)
- [ ] Screenshots attached (for visual changes) — no visual change, purely semantic

🤖 Generated with [Claude Code](https://claude.com/claude-code)