### PR TITLE
Add SRI hash and defer to Plotly script tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,13 @@
     />
 
     {% if page.plotly %}
-    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
+    <script
+      defer
+      src="https://cdn.plot.ly/plotly-2.35.2.min.js"
+      integrity="sha384-cCVCZkAjYNxaYKbM8lsArLznDF/SvMFr1jcZrvOpSTCa0W40ZAdLzHCEulnUa5i7"
+      crossorigin="anonymous"
+      charset="utf-8"
+    ></script>
     {% endif %} {% include jquery.html %} {% include mathjax.html %} {% include analytics_alt.html
     %} {%- seo -%}
 


### PR DESCRIPTION
## Summary

- Add `integrity` (sha384) and `crossorigin="anonymous"` to the Plotly CDN script tag for subresource integrity protection
- Add `defer` for non-render-blocking load
- Hash computed from actual `https://cdn.plot.ly/plotly-2.35.2.min.js` content, verified stable across multiple fetches
- Tested on a Plotly-heavy page (`implicit-function-learning`) — zero console errors

Closes #9

## Type of Change

- [x] Site improvement (layout, styling, functionality)

## Checklist

- [x] PR targets `netlify` branch (not `main`)
- [x] Tested locally with `bundle exec jekyll serve`
- [x] Site builds without errors (`bundle exec jekyll build`)
- [ ] Screenshots attached (for visual changes) — no visual change

🤖 Generated with [Claude Code](https://claude.com/claude-code)