### PR TITLE
Add alt text to 113 images for accessibility

### DIFF
--- a/ASSETS.md
+++ b/ASSETS.md
@@ -22,7 +22,7 @@ banner: https://assets.hummat.com/images/my-banner.jpg
 ```
 
 ```html
-<img src="https://assets.hummat.com/images/example.png" />
+<img src="https://assets.hummat.com/images/example.png" alt="Example image" />
 <div data-include="https://assets.hummat.com/figures/my-plot.html"></div>
 ```
 

--- a/_posts/2020-06-17-beautiful-blogging.md
+++ b/_posts/2020-06-17-beautiful-blogging.md
@@ -203,7 +203,7 @@ It stores the interactive figure inside HTML file which you can then include in 
 <div class="slideshow-container">
   <div class="mySlides fade">
     <div class="numbertext">1 / 2</div>
-    <img src="https://assets.hummat.com/images/2dgauss.png" style="width:100%">
+    <img src="https://assets.hummat.com/images/2dgauss.png" style="width:100%" alt="Static 2D Gaussian distribution surface plot">
     <div class="text">A normal image. Boring!</div>
   </div>
 

--- a/_posts/2020-07-17-a-sense-of-uncertainty.md
+++ b/_posts/2020-07-17-a-sense-of-uncertainty.md
@@ -63,7 +63,7 @@ Usually, uncertainty is put into two broad categories which makes it easier to t
 [^1]: Or _epistemic uncertainty_.
 
 <div style="text-align:center">
-  <img src="https://assets.hummat.com/images/deterministic_nn.png">
+  <img src="https://assets.hummat.com/images/deterministic_nn.png" alt="Diagram of a standard neural network with specific scalar weights on each connection">
   <figcaption>A standard neural network with specific weights [<a href="https://arxiv.org/abs/1505.05424">source</a>].</figcaption>
 </div>
 
@@ -72,7 +72,7 @@ This is equivalent to an old person having figured out the answers to all the im
 [^2]: Within the limited pool of possibilities granted to it during its design, captured by the choice of possible probability distributions used for modeling the likelihood of the weights.
 
 <div style="text-align:center">
-  <img src="https://assets.hummat.com/images/bayesian_nn.png">
+  <img src="https://assets.hummat.com/images/bayesian_nn.png" alt="Diagram of a Bayesian neural network with probability distributions over each weight">
   <figcaption>A Bayesian neural network with distributions over weights [<a href="https://arxiv.org/abs/1505.05424">source</a>].</figcaption>
 </div>
 
@@ -84,15 +84,15 @@ Below are some examples of data with low data uncertainty---the images are of go
 
 <div class="slideshow-container">
   <div class="mySlides fade">
-    <img src="https://assets.hummat.com/images/jaguar_leopard.jpg" style="width:100%">
+    <img src="https://assets.hummat.com/images/jaguar_leopard.jpg" style="width:100%" alt="Side-by-side comparison of a jaguar and a leopard">
   </div>
 
   <div class="mySlides fade">
-    <img src="https://assets.hummat.com/images/turtle_turtois.png" style="width:100%">
+    <img src="https://assets.hummat.com/images/turtle_turtois.png" style="width:100%" alt="Side-by-side comparison of a turtle and a tortoise">
   </div>
 
   <div class="mySlides fade">
-    <img src="https://assets.hummat.com/images/hare_rabbit.jpg" style="width:100%">
+    <img src="https://assets.hummat.com/images/hare_rabbit.jpg" style="width:100%" alt="Side-by-side comparison of a hare and a rabbit">
   </div>
 </div>
 

--- a/_posts/2020-07-28-laplace-approximation-for-bayesian-deep-learning.md
+++ b/_posts/2020-07-28-laplace-approximation-for-bayesian-deep-learning.md
@@ -178,7 +178,7 @@ $$
 The weight samples $W_t$ can be drawn efficiently from our posterior s.t. $W_t\sim\mathcal{N}(W^\star,\hat{F}^{-1})$. We then load them into our network, perform a standard forward pass on the new input to obtain the output and repeat this a couple of times. By averaging the output over all evaluations, we obtain the final result. In the limit, approaching an infinite number of weight samples, we reclaim the solution of the integral, but in practice, around $30$ such samples already lead to significantly improved results as we will see in the next section.
 
 <div style="text-align:center">
-  <img src="https://assets.hummat.com/images/bayesian_inference.jpg">
+  <img src="https://assets.hummat.com/images/bayesian_inference.jpg" alt="Diagram showing approximate Bayesian inference: weight samples drawn from the posterior are loaded into the network and predictions are averaged">
   <figcaption>Approximate Bayesian inference through sampling. [<a href="https://arxiv.org/abs/1812.01719v5">source</a>].</figcaption>
 </div>
 
@@ -242,11 +242,11 @@ What we want in these settings is an algorithm that provides correct predictions
 
 <div style="text-align: center;">
 <figure style="width: 35%; display: inline-block;">
-    <img src='/images/imagenet.jpg'/>
+    <img src='/images/imagenet.jpg' alt="Photograph of an object from the ImageNet dataset"/>
     <figcaption>A "normal" input.</figcaption>
 </figure>
 <figure style="width: 30%; display: inline-block">
-    <img src='/images/art.jpg'/>
+    <img src='/images/art.jpg' alt="Artistic painting used as out-of-distribution input"/>
     <figcaption>A strange input.</figcaption>
 </figure>
 </div>

--- a/_posts/2020-10-16-flatlands.md
+++ b/_posts/2020-10-16-flatlands.md
@@ -28,7 +28,7 @@ As the name suggests, a point cloud is an agglomeration of points in three dimen
 From the given perspective, there is not a lot to see or understand. Now, if you haven't already, try zooming out using your mouse wheel (or fingers). As you might notice, a distinctive shape emerges, namely that of the _Happy Buddha_ from [The Stanford 3D Scanning Repository](https://graphics.stanford.edu/data/3Dscanrep/), where the color of each point encodes the distance from the viewer (depth). Here is an image of it from the front:
 
 <div style="text-align:center;">
-  <img src="https://assets.hummat.com/images/happy_buddha.jpg" style="max-height:700px">
+  <img src="https://assets.hummat.com/images/happy_buddha.jpg" style="max-height:700px" alt="Front view of the Happy Buddha statue from the Stanford 3D Scanning Repository">
 </div>
 
 ## Images vs. point clouds

--- a/_posts/2020-10-29-one-by-one-conv.md
+++ b/_posts/2020-10-29-one-by-one-conv.md
@@ -26,11 +26,11 @@ where $b$ is an offset, usually called the _bias_ (not shown in the figure). Thi
 
 <div style="text-align: center">
 <figure style="width: 45%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/fc_vs_conv/fc_single.png">
+  <img src="https://assets.hummat.com/images/fc_vs_conv/fc_single.png" alt="Diagram of a single fully connected neuron with weight connections to two input pixels">
   <figcaption style="text-align: left;  line-height: 1.2em;"><b>Fig. 1 (a):</b> A single fully connected neuron, only showing connections (weights $w$) for two inputs (pixel).</figcaption>
 </figure>
 <figure style="width: 45%; display: inline-block">
-  <img src="https://assets.hummat.com/images/fc_vs_conv/fc_full.png">
+  <img src="https://assets.hummat.com/images/fc_vs_conv/fc_full.png" alt="Diagram of a fully connected layer showing four of 784 neurons with two input connections each">
   <figcaption style="text-align: left; line-height: 1.2em;"><b>Fig. 1 (b):</b> A fully connected layer, only showing four of the $784$ neurons and two of the $784$ inputs each.</figcaption>
 </figure>
 </div>
@@ -43,11 +43,11 @@ A standard convolutional layer is defined by the number of input channels, e.g. 
 
 <div style="text-align: center">
 <figure style="width: 45%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/fc_vs_conv/conv_slide.png">
+  <img src="https://assets.hummat.com/images/fc_vs_conv/conv_slide.png" alt="Diagram of a standard convolution with a single 3x3 kernel sliding over the input">
   <figcaption style="text-align: left;  line-height: 1.2em;"><b>Fig. 2 (a):</b> A standard convolution of a single filter with one $3\times3$ kernel.<br><br></figcaption>
 </figure>
 <figure style="width: 45%; display: inline-block">
-  <img src="https://assets.hummat.com/images/fc_vs_conv/fc_slide.png">
+  <img src="https://assets.hummat.com/images/fc_vs_conv/fc_slide.png" alt="Diagram of a sliding fully connected layer restricted to 9 adjacent input pixels">
   <figcaption style="text-align: left; line-height: 1.2em;"><b>Fig. 2 (b):</b> Conceptually simple: Sliding a "fully connected" layer over the image, restricting it to $9$ adjacent inputs.</figcaption>
 </figure>
 </div>
@@ -59,7 +59,7 @@ The idea of sliding a small network over the input, as shown in fig. 2 (b), init
 
 <div style="text-align: center">
 <figure style="width: 90%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/fc_vs_conv/conv_full2.png">
+  <img src="https://assets.hummat.com/images/fc_vs_conv/conv_full2.png" alt="Diagram of a convolution with 28x28 kernels mimicking a fully connected layer">
   <figcaption style="text-align: left;  line-height: 1.2em;"><b>Fig. 3:</b> The operation of a fully connected layer on a two-dimensional input (only looking at spatial dimensions here, not depth, i.e. number of channels) can be described by a convolution with one kernel (weight matrix) per input channel (one) of the same size as the input ($28\times28$ pixel), repeated for each input pixel (i.e. $784$ filter/output channel).</figcaption>
 </figure>
 </div>
@@ -70,11 +70,11 @@ If we reduce the width and height of our filter kernels to one, we obtain $1\tim
 
 <div style="text-align: center">
 <figure style="width: 45%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/fc_vs_conv/conv_rgb.png">
+  <img src="https://assets.hummat.com/images/fc_vs_conv/conv_rgb.png" alt="Diagram of a 1x1 convolution with three kernels operating on an RGB image">
   <figcaption style="text-align: left;  line-height: 1.2em;"><b>Fig. 4 (a):</b> A standard convolution of a single filter with three $1\times1$ kernels.<br><br></figcaption>
 </figure>
 <figure style="width: 45%; display: inline-block">
-  <img src="https://assets.hummat.com/images/fc_vs_conv/fc_rgb.png">
+  <img src="https://assets.hummat.com/images/fc_vs_conv/fc_rgb.png" alt="Diagram of a sliding fully connected layer on an RGB image, one pixel per channel">
   <figcaption style="text-align: left; line-height: 1.2em;"><b>Fig. 4 (b):</b> Conceptually simple: Sliding a "fully connected" layer over the image, restricting it to one pixel per channel.</figcaption>
 </figure>
 </div>
@@ -87,11 +87,11 @@ The important thing to note here is, that both approaches produce a _single_ out
 
 <div style="text-align: center">
 <figure style="width: 45%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/fc_vs_conv/conv_slide2.png" style="padding: 50px 0 50px 0">
+  <img src="https://assets.hummat.com/images/fc_vs_conv/conv_slide2.png" style="padding: 50px 0 50px 0" alt="Diagram of 1x1 convolutions producing class feature maps with one filter per class">
   <figcaption style="text-align: left;  line-height: 1.2em;"><b>Fig. 5 (a):</b> Using $1\times1$ convolutions to produce "class" feature maps with <em>one filter</em> per class.<br><br></figcaption>
 </figure>
 <figure style="width: 45%; display: inline-block">
-  <img src="https://assets.hummat.com/images/fc_vs_conv/fc_slide2.png">
+  <img src="https://assets.hummat.com/images/fc_vs_conv/fc_slide2.png" alt="Diagram of a sliding fully connected layer producing class feature maps">
   <figcaption style="text-align: left; line-height: 1.2em;"><b>Fig. 5 (b):</b> The same effect achieved with a fully connected approach, were we to focus on one pixel at a time and capable of sliding the layer across the input.</figcaption>
 </figure>
 </div>
@@ -102,11 +102,11 @@ Armed with the knowledge from the previous paragraph, we can now understand the 
 
 <div style="text-align: center">
 <figure style="width: 45%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/fc_vs_conv/conv_single1.png" style="padding: 50px 0 50px 0">
+  <img src="https://assets.hummat.com/images/fc_vs_conv/conv_single1.png" style="padding: 50px 0 50px 0" alt="Diagram of a reshaped image as a 1x1x784 vector convolved with a single filter of 784 1x1 kernels">
   <figcaption style="text-align: left;  line-height: 1.2em;"><b>Fig. 6 (a):</b> A $28\times28$ pixel image transformed into a $1\times1\times784$ vector (left) is convolved with a single filter with $784$ one-by-one kernels (right) producing a single scalar value.</figcaption>
 </figure>
 <figure style="width: 45%; display: inline-block">
-  <img src="https://assets.hummat.com/images/fc_vs_conv/conv_full1.png">
+  <img src="https://assets.hummat.com/images/fc_vs_conv/conv_full1.png" alt="Diagram of a reshaped image convolved with 784 filters, each with 784 1x1 kernels">
   <figcaption style="text-align: left; line-height: 1.2em;"><b>Fig. 6 (b):</b> The same input image as in (a), but now convolved with $784$ filters, each with $784$ one-by-one kernels, producing $784$ scalar outputs.<br><br></figcaption>
 </figure>
 </div>

--- a/_posts/2020-11-03-learning-from-point-clouds.md
+++ b/_posts/2020-11-03-learning-from-point-clouds.md
@@ -61,7 +61,7 @@ Another idea would be, to _"slide"_ a network with $3$ inputs, one for each spat
 
 <div style="text-align: center">
 <figure style="width: 90%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/fc_vs_conv/pointnet_mlp.png">
+  <img src="https://assets.hummat.com/images/fc_vs_conv/pointnet_mlp.png" alt="Diagram of a shared MLP sliding over each point in the point cloud with three inputs per point">
   <figcaption style="text-align: left;  line-height: 1.2em;"><b>Fig. 1:</b> A "shared" MLP with three inputs ($x,y,z$ coordinates) "sliding" over each point in the point cloud.</figcaption>
 </figure>
 </div>
@@ -72,7 +72,7 @@ On the input layer, we can replace our fully connected layer from figure 1 with 
 
 <div style="text-align: center">
 <figure style="width: 80%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/fc_vs_conv/pointnet_conv2.png">
+  <img src="https://assets.hummat.com/images/fc_vs_conv/pointnet_conv2.png" alt="Diagram of 1x3 convolutions replacing the shared MLP in PointNet">
   <figcaption style="text-align: left;  line-height: 1.2em;"><b>Fig. 2:</b> The "shared" MLP from before is replace by $1\times3$ convolutions.</figcaption>
 </figure>
 </div>
@@ -81,7 +81,7 @@ We could also use a second approach of employing $1\times1$ convolutions, which 
 
 <div style="text-align: center">
 <figure style="width: 60%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/fc_vs_conv/pointnet_conv1.png">
+  <img src="https://assets.hummat.com/images/fc_vs_conv/pointnet_conv1.png" alt="Diagram of 1x1 convolutions mimicking a shared MLP in PointNet">
   <figcaption style="text-align: left;  line-height: 1.2em;"><b>Fig. 3:</b> The "shared" MLP is mimicked by $1\times1$ convolutions inside the network (shown on the input here though).</figcaption>
 </figure>
 </div>
@@ -90,7 +90,7 @@ If we now have a look at the entire network architecture as presented in the pap
 
 <div style="text-align: center">
 <figure style="width: 100%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/pointnet.png">
+  <img src="https://assets.hummat.com/images/pointnet.png" alt="PointNet architecture diagram showing classification and segmentation networks">
   <figcaption style="text-align: left; line-height: 1.2em;"><b>Fig. 4:</b> PointNet as presented in the original paper. [<a href="https://openaccess.thecvf.com/content_cvpr_2017/papers/Qi_PointNet_Deep_Learning_CVPR_2017_paper.pdf">source</a>]</figcaption>
 </figure>
 </div>
@@ -102,7 +102,7 @@ This has the added advantage that the network is pushed to reduce each object to
 
 <div style="text-align: center">
 <figure style="width: 70%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/pointnet_critical_points.png">
+  <img src="https://assets.hummat.com/images/pointnet_critical_points.png" alt="PointNet critical points showing object skeletons that determine classification">
   <figcaption style="text-align: left;  line-height: 1.2em;"><b>Fig. 5:</b> The minimum (critical) and maximum (upper-bound) number of points which don't change PointNets classification results. [<a href="https://openaccess.thecvf.com/content_cvpr_2017/papers/Qi_PointNet_Deep_Learning_CVPR_2017_paper.pdf">source</a>]</figcaption>
 </figure>
 </div>

--- a/_posts/2020-12-17-learning-from-voxels.md
+++ b/_posts/2020-12-17-learning-from-voxels.md
@@ -86,7 +86,7 @@ So you have some 3D data lying around and now you want to extract some informati
 
 <div style="text-align: center">
 <figure style="width: 70%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/voxnet.png">
+  <img src="https://assets.hummat.com/images/voxnet.png" alt="VoxNet architecture diagram showing 3D convolutional and fully connected layers">
   <figcaption style="text-align: center; line-height: 1.2em;"><b>VoxNet</b> [<a href="https://dimatura.net/publications/voxnet_maturana_scherer_iros15.pdf">source</a>]</figcaption>
 </figure>
 </div>
@@ -107,7 +107,7 @@ The authors of [_OctNet_](https://openaccess.thecvf.com/content_cvpr_2017/papers
 
 <div style="text-align: center">
 <figure style="width: 70%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/octree.png">
+  <img src="https://assets.hummat.com/images/octree.png" alt="Octree data structure recursively subdividing 3D space into eight octants">
   <figcaption style="text-align: center; line-height: 1.2em;"><b>Octree</b> [<a href="https://openaccess.thecvf.com/content_cvpr_2017/papers/Riegler_OctNet_Learning_Deep_CVPR_2017_paper.pdf">source</a>]</figcaption>
 </figure>
 </div>
@@ -116,7 +116,7 @@ In our case, information can be a point from a point cloud or a face, vertex or 
 
 <div style="text-align: center">
 <figure style="width: 70%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/octnet.png">
+  <img src="https://assets.hummat.com/images/octnet.png" alt="OctNet using octree-based adaptive resolution for efficient 3D convolutions">
   <figcaption style="text-align: center; line-height: 1.2em;"><b>OctNet</b> [<a href="https://openaccess.thecvf.com/content_cvpr_2017/papers/Riegler_OctNet_Learning_Deep_CVPR_2017_paper.pdf">source</a>]</figcaption>
 </figure>
 </div>

--- a/_posts/2020-12-22-learning-from-graphs.md
+++ b/_posts/2020-12-22-learning-from-graphs.md
@@ -61,7 +61,7 @@ To take advantage of the structure inherent in meshes, the creators of MeshNet d
 
 <div style="text-align: center">
 <figure style="width: 60%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/meshnet_features.png">
+  <img src="https://assets.hummat.com/images/meshnet_features.png" alt="MeshNet spatial and structural feature extraction from mesh faces">
   <figcaption style="text-align: center; line-height: 1.2em;"><b>MeshNet features</b> [<a href="https://arxiv.org/abs/1811.11424">source</a>]</figcaption>
 </figure>
 </div>
@@ -76,7 +76,7 @@ Similar to the previous architecture, this one is also specifically designed to 
 
 <div style="text-align: center">
 <figure style="width: 100%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/meshcnn.png">
+  <img src="https://assets.hummat.com/images/meshcnn.png" alt="MeshCNN edge-based features and mesh pooling operations">
   <figcaption style="text-align: center; line-height: 1.2em;"><b>MeshCNN features (a) and pooling (b, c)</b> [<a href="https://arxiv.org/abs/1809.05910">source</a>]</figcaption>
 </figure>
 </div>
@@ -85,14 +85,14 @@ The convolution is defined similarly to MeshNet over the participating edges. To
 
 <div style="text-align: center">
 <figure style="width: 20%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/meshcnn_conv.png">
+  <img src="https://assets.hummat.com/images/meshcnn_conv.png" alt="MeshCNN convolution operation on mesh edges">
   <figcaption style="text-align: left;  line-height: 1.2em;"><b>Convolution</b> [<a href="https://arxiv.org/abs/1809.05910">source</a>]</figcaption>
 </figure>
 <figure style="width: 15%; display: inline-block;">
   <figcaption style="text-align: left;  line-height: 1.2em;"></figcaption>
 </figure>
 <figure style="width: 25%; display: inline-block">
-<img src="https://assets.hummat.com/images/meshcnn_features.png">
+<img src="https://assets.hummat.com/images/meshcnn_features.png" alt="MeshCNN edge features: inner angles, dihedral angle, and edge length ratios">
   <figcaption style="text-align: left; line-height: 1.2em;"><b>Edge Features</b> [<a href="https://arxiv.org/abs/1809.05910">source</a>]</figcaption>
 </figure>
 </div>
@@ -107,7 +107,7 @@ In contrast to other works, including those featured above, DGCNN creates its ow
 
 <div style="text-align: center">
 <figure style="width: 90%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/dgcnn_features.png">
+  <img src="https://assets.hummat.com/images/dgcnn_features.png" alt="DGCNN EdgeConv operation computing pairwise edge features from dynamic k-nearest neighbor graphs">
   <figcaption style="text-align: center; line-height: 1.2em;"><b>DGCNN EdgeConv</b> [<a href="https://arxiv.org/abs/1801.07829">source</a>]</figcaption>
 </figure>
 </div>

--- a/_posts/2021-02-04-learning-from-projections.md
+++ b/_posts/2021-02-04-learning-from-projections.md
@@ -56,7 +56,7 @@ In the seminal _Multi-view Convolutional Neural Networks for 3D Shape Recognitio
 
 <div style="text-align: center">
 <figure style="width: 70%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/multi-view.png">
+  <img src="https://assets.hummat.com/images/multi-view.png" alt="Multiple 2D views of a 3D object rendered from 12 different viewpoints">
   <figcaption style="text-align: center; line-height: 1.2em;"><b>Multiple views</b> [<a href="https://arxiv.org/abs/1505.00880">source</a>]</figcaption>
 </figure>
 </div>
@@ -65,7 +65,7 @@ As in standard 2D object classification, they then used a convolutional neural n
 
 <div style="text-align: center">
 <figure style="width: 70%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/mvcnn.png">
+  <img src="https://assets.hummat.com/images/mvcnn.png" alt="Multi-view CNN architecture processing multiple views through shared CNNs with max pooling">
   <figcaption style="text-align: center; line-height: 1.2em;"><b>The model</b> [<a href="https://arxiv.org/abs/1505.00880">source</a>]</figcaption>
 </figure>
 </div>
@@ -76,7 +76,7 @@ A similar idea was used in _Multi-View 3D Object Detection Network for Autonomou
 
 <div style="text-align: center">
 <figure style="width: 95%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/mv3d.png">
+  <img src="https://assets.hummat.com/images/mv3d.png" alt="Multi-view 3D object detection network fusing LiDAR bird's eye view, front view, and RGB image">
   <figcaption style="text-align: center; line-height: 1.2em;"><b>3D object detection</b> [<a href="https://arxiv.org/abs/1611.07759">source</a>]</figcaption>
 </figure>
 </div>
@@ -89,7 +89,7 @@ While not an officially recognised category, projecting 3D objects onto geometri
 
 <div style="text-align: center">
 <figure style="width: 95%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/deeppano.png">
+  <img src="https://assets.hummat.com/images/deeppano.png" alt="DeepPano cylindrical projection of a 3D object for panoramic shape recognition">
   <figcaption style="text-align: center; line-height: 1.2em;"><b>Cylindrical projection</b> [<a href="https://ieeexplore.ieee.org/document/7273863">source</a>]</figcaption>
 </figure>
 </div>
@@ -98,7 +98,7 @@ Now, you might wonder, if one can use object panoramas, why not use 360° views?
 
 <div style="text-align: center">
 <figure style="width: 95%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/spherical_cnn.png">
+  <img src="https://assets.hummat.com/images/spherical_cnn.png" alt="Spherical projection of a 3D object cut into stripes and fed to a CNN">
   <figcaption style="text-align: center; line-height: 1.2em;"><b>Spherical projection</b> [<a href="https://ieeexplore.ieee.org/document/8374611">source</a>]</figcaption>
 </figure>
 </div>
@@ -107,7 +107,7 @@ Finally, in a similar approach as the previous one, the authors of _Deep Learnin
 
 <div style="text-align: center">
 <figure style="width: 60%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/geometry_image.png">
+  <img src="https://assets.hummat.com/images/geometry_image.png" alt="Geometry image pipeline: 3D object projected onto sphere then mapped to 2D plane">
   <figcaption style="text-align: center; line-height: 1.2em;"><b>From object to sphere to plane</b> [<a href="https://engineering.purdue.edu/cdesign/wp/wp-content/uploads/2016/12/Deep-Learning-3D-shape-Surfaces-Using-Geometry-Images.pdf">source</a>]</figcaption>
 </figure>
 </div>

--- a/_posts/2021-05-27-on-context.md
+++ b/_posts/2021-05-27-on-context.md
@@ -32,7 +32,7 @@ Let's look at a couple of examples. The simplest (an therefore the one we will s
 
 Did you guess the meaning correctly? Or was it the financial institution or place to sit? The point is, of course, that you couldn't have known without the context of the entire sentence, as many words are ambiguous. It doesn't stop there though. Even the sentence is ambiguous if your goal is to determine the book title or author who wrote it. To do so, you might need a paragraph, a page or even an entire chapter of context. In machine learning lingo, such broad context is commonly called a _long-range dependency_. Here is another one. Pay attention to the meaning of the word _it_:
 
-![](https://assets.hummat.com/images/attention/it.gif)
+![Animated sentence where the word 'it' changes meaning depending on whether 'tired' or 'wide' follows](https://assets.hummat.com/images/attention/it.gif)
 
 Seeing _tired_, we know _it_ must refer to the animal, as roads are seldom so while it's the opposite for _wide_[^2].
 
@@ -56,7 +56,7 @@ Below, there are two more examples of increasing dimensionality (use the little 
 
 Again, context doesn't stop there. To correctly place a pixel as belonging to, say, an eye, you need the surrounding pixels making up the eye. To place the eye as coming from an adult or a child you make use of the information stored in the pixels around the eye. Such inference can potentially go on indefinitely, but it's usually restricted by the size of the depicted scene or the resolution of the image. Okay, you might think, so is more information always better? No.
 
-![](https://assets.hummat.com/images/attention/knowledge.gif)
+![Animated image where hidden information becomes visible when surrounding context is removed](https://assets.hummat.com/images/attention/knowledge.gif)
 
 Finding the hidden information in the image above is trivial if the surrounding context is removed (to be precise, it's not the _absence_ of context, as all pixels are still there, but the _contrast_ between signal and noise, percieved as difference between gray and colored pixels). Clearly, it's not a simple as having no context at all or all of it but rather which portion of the provided information we pay _attention_ to.
 

--- a/_posts/2021-05-27-on-context.md
+++ b/_posts/2021-05-27-on-context.md
@@ -28,7 +28,7 @@ It all begins with a little entity making up most of the (digital) world around 
 
 Let's look at a couple of examples. The simplest (an therefore the one we will see most frequently throughout the article) is the word. Try to guess the meaning of the word below, then hover over it with your mouse (or tap on it) to reveal the context:
 
-<img class="img-animate" src="https://assets.hummat.com/images/attention/bank.png">
+<img class="img-animate" src="https://assets.hummat.com/images/attention/bank.png" alt="The word 'bank' shown in isolation; hover to reveal the disambiguating sentence context">
 
 Did you guess the meaning correctly? Or was it the financial institution or place to sit? The point is, of course, that you couldn't have known without the context of the entire sentence, as many words are ambiguous. It doesn't stop there though. Even the sentence is ambiguous if your goal is to determine the book title or author who wrote it. To do so, you might need a paragraph, a page or even an entire chapter of context. In machine learning lingo, such broad context is commonly called a _long-range dependency_. Here is another one. Pay attention to the meaning of the word _it_:
 
@@ -76,7 +76,7 @@ For a long time, the predominant method used to model natural language was the _
 
 <div style="text-align: center">
 <figure style="width: 90%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/attention/rnn_unrolled.png">
+  <img src="https://assets.hummat.com/images/attention/rnn_unrolled.png" alt="Unrolled recurrent neural network processing input elements sequentially while retaining hidden state">
   <figcaption style="text-align: left; line-height: 1.2em;"><b>An unrolled RNN:</b> Input elements $\boldsymbol{x}_t$ are processed sequentially while context is retained in the hidden states $\boldsymbol{h}_t$. Taken from [<a href="#ref1">1</a>].</figcaption>
 </figure>
 </div>
@@ -90,7 +90,7 @@ However, there are at least two tricks to aggregate long-range dependencies usin
 
 <div style="text-align: center">
 <figure style="width: 90%; display: inline-block;">
-  <img width="400" style="margin-left: auto; margin-right: auto;" src="https://assets.hummat.com/images/attention/1d_conv.png">
+  <img width="400" style="margin-left: auto; margin-right: auto;" src="https://assets.hummat.com/images/attention/1d_conv.png" alt="Stacked 1D convolutional layers with growing receptive field highlighted in red">
   <figcaption style="text-align: left; line-height: 1.2em;"><b>Receptive field:</b> The receptive field (red) is the range of context aggregated into the current representation. It increases with the number of stacked convolutional layers. Adapted from [<a href="#ref2">2</a>].</figcaption>
 </figure>
 </div>
@@ -99,7 +99,7 @@ Now, for large inputs (a long text, a high resolution image, a dense point cloud
 
 <div style="text-align: center">
 <figure style="width: 90%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/attention/wavenet.gif">
+  <img src="https://assets.hummat.com/images/attention/wavenet.gif" alt="Animated WaveNet architecture using stacked dilated convolutions for large receptive fields">
   <figcaption style="text-align: left; line-height: 1.2em;"><b>WaveNet:</b> Using dilated convolutions, long sequences can be processed efficiently while retaining a large receptive field. Taken from [<a href="#ref3">3</a>].</figcaption>
 </figure>
 </div>
@@ -108,7 +108,7 @@ Moving to the image domain, there is no fundamentally new idea here as vision mo
 
 <div style="text-align: center">
 <figure style="width: 90%; display: inline-block;">
-  <img src="https://assets.hummat.com/images/attention/dilated.gif">
+  <img src="https://assets.hummat.com/images/attention/dilated.gif" alt="Animated 2D dilated convolution showing increasing dilation factors">
   <figcaption style="text-align: left; line-height: 1.2em;"><b>Dilation in 2D:</b> Concepts like strided and dilated convolutions work identically in one, two or three dimensions. Taken from [<a href="#ref4">4</a>].</figcaption>
 </figure>
 </div>
@@ -123,7 +123,7 @@ Adding a third dimension, things get more interesting again, as the computationa
     {% if page.slow %}
     <div data-include="https://assets.hummat.com/figures/bunny_with_spheres.html"></div>
     {% else %}
-    <img src="https://assets.hummat.com/images/bunny.png">
+    <img src="https://assets.hummat.com/images/bunny.png" alt="Stanford Bunny point cloud with context regions defined by farthest point sampling">
     {% endif %}
     <div class="text" style="text-align: left; bottomt: -60px; width: 90%;"><b>Point context:</b> Defining context regions using farthest point sampling and ball queries.</div>
   </div>
@@ -132,7 +132,7 @@ Adding a third dimension, things get more interesting again, as the computationa
     {% if page.slow %}
     <div data-include="https://assets.hummat.com/figures/3d_conv.html"></div>
     {% else %}
-    <img src="https://assets.hummat.com/images/3d_conv.png">
+    <img src="https://assets.hummat.com/images/3d_conv.png" alt="3D convolution kernel sliding over a voxel grid">
     {% endif %}
     <div class="text" style="text-align: left; bottom: -60px; width: 90%;"><b>Convolutions in 3D:</b> Adding a dimension drastically increases the computational burden of convolutions, making them cumbersome in the 3D domain.</div>
   </div>
@@ -141,7 +141,7 @@ Adding a third dimension, things get more interesting again, as the computationa
     {% if page.slow %}
     <div data-include="https://assets.hummat.com/figures/graph.html"></div>
     {% else %}
-    <img width="220" style="margin-left: auto; margin-right: auto; display: block;" src="https://assets.hummat.com/images/mesh.png">
+    <img width="220" style="margin-left: auto; margin-right: auto; display: block;" src="https://assets.hummat.com/images/mesh.png" alt="Triangle mesh of the Happy Buddha where connectivity provides graph context">
     {% endif %}
     <div class="text" style="text-align: left; bottom: -60px; width: 90%;"><b>Graph context:</b> A mesh can be interpreted as a graph where context is expressed through connectivity.</div>
   </div>

--- a/_posts/2021-05-31-attention.md
+++ b/_posts/2021-05-31-attention.md
@@ -20,7 +20,7 @@ You might be wondering if this article can possibly contain anything new for you
 
 Our detailed explanation of the attention mechanism begins with some math which will subsequently be visualized to build an intuitive understanding. A quick word on notation: The attention equation makes use of scalars, vectors and matrices. We will use lowercase letters $x$, bold lowercase letters $\boldsymbol{x}$ and uppercase letters $W$ for these entities respectively. A great way to visualize scalars, vectors and matrices is to represent them by colored squares, where the number of squares represents the dimensionality and the shade of the color in each square represents the magnitude of the value at this position from small, bright values to large, dark values as shown below.
 
-<img class="img-animate" src="https://assets.hummat.com/images/attention/notation.png">
+<img class="img-animate" src="https://assets.hummat.com/images/attention/notation.png" alt="Visual notation guide: scalars as single squares, vectors as rows of squares, matrices as grids with shade encoding magnitude">
 
 Most illustrations in this article are animated. Simply hover over them with your mouse (or tap on them) to activate the animation.
 
@@ -40,7 +40,7 @@ So what's happening here? In a nutshell: The output of the attention operation $
 
 What are those weights $w\_{ij}$ then and how are they determined? Though we employ attention in the deep learning domain, in it's most basic form, it actually doesn't contain any learnable parameters. Instead, the weights are computed from the inputs using the dot product as similarity measure: $w\_{ij}=\boldsymbol{x}\_i^T\boldsymbol{x}\_j$. To understand how this works and why it makes sense, let's take a look at the visualization below (reminder: hover over or tap on the image to activate the animation).
 
-<img class="img-animate" src="https://assets.hummat.com/images/attention/dot_product.png">
+<img class="img-animate" src="https://assets.hummat.com/images/attention/dot_product.png" alt="Animated dot product between user preference and movie content vectors computing a similarity score">
 
 The two vectors $\boldsymbol{u}$ and $\boldsymbol{m}$ represent the movie preferences of a user and the movie content respectively with three features each. Now, taking the dot product, we get a score representing the match between user and movie. Note that this takes into account both the magnitude of the values, as multiplying large values results in a large increase of the score, as well as the sign. Imagine a scale between $-1$ and $1$ where the former represent strong dislike (or weak occurance in case of the movie vector) and the latter a strong inclination (or strong occurance). Now, given a user who dislikes action and a movie with little action, the score will still be high as both negative signs cancel out, which is exactly what we want.
 To make those weights more interpretable and prevent the output from becoming excessively large, we can squish all weights $\boldsymbol{w}\_j=\{w\_{ij}\}\_{i=1}^N$ to fall between $0$ and $1$ using the _softmax_ function which is reminiscent of its application on the logits in classification tasks. We can think of the resulting normalized weight vector as a categorical probability distribution over the inputs where high probability is assigned to inputs with strong similarity[^2] and attention itself as expected value of the inputs.
@@ -53,7 +53,7 @@ Once all weights are computed, we multiply them with their corresponding inputs 
 
 [^3]: This is omitted in the basic attention equation but we will include it in the upcoming matrix notation.
 
-<img class="img-animate" src="https://assets.hummat.com/images/attention/attention.png">
+<img class="img-animate" src="https://assets.hummat.com/images/attention/attention.png" alt="Animated basic attention: dot product weights computed between inputs, softmax applied, weighted sum produces output">
 
 As in the dot product example, think of the transposed vectors (the horizontal ones) as individual users and the vertical ones as movies. The outputs would then represent something akin to an ideal movie, one for each user, stitched together from the three individual movies on offer.
 
@@ -103,7 +103,7 @@ $$
 
 Returning to our running example, the query takes on the role of the user, asking the question: _"Which movies match my taste?"_ while the key encodes the movies content and the value represents the movie itself. Using this updated definition, the computation performed by the attention operation can be visualized as follows.
 
-<img class="img-animate" src="https://assets.hummat.com/images/attention/query_key_value.png">
+<img class="img-animate" src="https://assets.hummat.com/images/attention/query_key_value.png" alt="Animated query-key-value attention: inputs projected into Q, K, V; dot product of Q and K produces weights for V">
 
 We can add these changes to our basic attention implementation with a few lines of code:
 
@@ -150,7 +150,7 @@ y_3 = np.sum([w * v for w, v in zip(w_3j, v_i)], axis=0)
 
 The terms _key_ and _value_ might remind you of dictionaries used across programming languages, where values can be stored and retrieved efficiently using a hash of the key. Indeed, such dictionaries are nothing but the digital successor of file cabinets where files (values) are stored in folders with labels (keys). Given the task to retrieve a specific file (query) you would find it by comparing the search term to all labels. Using this analogy, we can understand attention as a _soft dictionary_, returning every value to the extend that its key matches the query.
 
-<img class="img-animate" src="https://assets.hummat.com/images/attention/dict.png">
+<img class="img-animate" src="https://assets.hummat.com/images/attention/dict.png" alt="Animated soft dictionary analogy: query matches against keys to retrieve weighted combination of values">
 
 ### Parallelization using matrices
 
@@ -158,13 +158,13 @@ From the illustrations you might get the impression that attention is computed s
 
 [^5]: Remember, we are dealing with sets of elements, in this case pixels, which are feature vectors, in this case the RGB color values.
 
-<img class="img-animate" src="https://assets.hummat.com/images/attention/parallel.png">
+<img class="img-animate" src="https://assets.hummat.com/images/attention/parallel.png" alt="Animated parallel computation: input matrix multiplied with Q, K, V weight matrices simultaneously">
 
 The obtained query, key and value _matrices_ $Q$, $K$ and $V$ then simply replace the individual values in the attention equation. Note how this conveniently eliminates the need for summation, an inherent feature of matrix multiplication, and that the softmax function can be applied immediately as all weights are computed simultaneously[^6].
 
 [^6]: Note that $QK^T$ computes a matrix of weights where each _row_ holds the weights for the weighted sum of each output so the softmax function needs to be applied _row-wise_.
 
-<img class="img-animate" src="https://assets.hummat.com/images/attention/matrix_attention.png">
+<img class="img-animate" src="https://assets.hummat.com/images/attention/matrix_attention.png" alt="Animated matrix attention: softmax of Q times K-transpose multiplied by V produces output matrix">
 
 ```python
 import numpy as np
@@ -204,7 +204,7 @@ Dividing the values inside the softmax function by a scalar is known as _temperi
 
 To understand the need for multiple heads when employing attention, let's consider the following example.
 
-<img class="img-animate" src="https://assets.hummat.com/images/attention/mary_susan.png">
+<img class="img-animate" src="https://assets.hummat.com/images/attention/mary_susan.png" alt="Animated example: 'Mary gave Susan' showing why single-head attention cannot distinguish giver from receiver">
 
 Focusing on the word _gave_, our single-headed approach will place equal attention on _Susan_ and _Mary_, as per the _distributional hypothesis_ (see below), $\boldsymbol{x}\_{susan}\approx\boldsymbol{x}\_{mary}$ which implies $\boldsymbol{q}\_{susan}\approx\boldsymbol{q}\_{mary}$ bringing us to $w\_{susan,mary}\approx w\_{mary,susan}$.
 
@@ -215,20 +215,20 @@ In other words, we can't discern the giver from the receiver. Another way to loo
 A more challenging problem is depicted below in the form of an ambiguous sentence which we have already encountered in the [introductory article](/learning/2021/05/27/on-context.html):
 
 <p align="center">
-  <img src="https://assets.hummat.com/images/attention/one_head.png">
+  <img src="https://assets.hummat.com/images/attention/one_head.png" alt="Single attention head weights for the ambiguous word 'it' attending to all other words in the sentence">
 </p>
 
 Attention weights between _it_ and all other words in the sentence are shown where darker shades correspond to greater magnitude. The meaning of _it_ is ambiguous, as it can correspond to _animal_ or _road_. Input $\boldsymbol{x}\_{it}$ only has access to a single attention weight vector $\boldsymbol{w}\_{it,k}$ though, where $k$ corresponds to all other words in the sentence (or more precisly, all of their _keys_). Thus we can only pay attention to either _animal_ or _road_ but not both. Technically we could place equal weights on both, but that doesn't help in parsing the meaning of _it_ either. The intuitive solution is to have two attention weight vectors, encoding two different meanings of our ambiguous word. This is precisely what multi-head attention achieves.
 
 <p align="center">
-  <img src="https://assets.hummat.com/images/attention/two_heads.png">
+  <img src="https://assets.hummat.com/images/attention/two_heads.png" alt="Two attention heads resolving ambiguity: one head attends to 'animal', the other to 'road'">
 </p>
 
 Multi-head attention is exactly like normal attention, just multiple times. Instead of a single $W^Q$, $W^K$ and $W^V$ matrix we now have $h$ of each. As this would increase the computational complexity by a factor of $h$, we divide the dimensionality of the weight matrices by this factor. Our matrices $W^Q\in\mathbb{R}^{d\times d\_k}$, $W^K\in\mathbb{R}^{d\times d\_k}$ and $W^V\in\mathbb{R}^{d\times d\_v}$ become $h$ matrices $W\_i^Q\in\mathbb{R}^{d\times d\_k/h}$, $W\_i^K\in\mathbb{R}^{d\times d\_k/h}$ and $W\_i^V\in\mathbb{R}^{d\times d\_v/h}$ with inputs $\boldsymbol{x}\in\mathbb{R}^d$, queries and keys $\boldsymbol{q,k}\in\mathbb{R}^{d\_k}$ and values $\boldsymbol{v}\in\mathbb{R}^{d\_v}$. In practise, $d\_k=d\_v=d/h$ so let's ditch $d\_v$ for simplicity.
 
 There remain two things we need to take care of. First, we don't want to apply attention sequentially $h$ times, so we stack the $h$ weight matrices for queries, keys and values respectively and then multiply them with the inputs which results in one query, key and value vector of dimension $hd\_k$ instead of $h$ each of dimension $d\_k$. Second, we want the output to have the same dimensionality as the input, so we introduce a final _output_ weight matrix $W^O\in\mathbb{R}^{hd\_k\times d}$ which transforms our intermediate outputs $\boldsymbol{z}\in\mathbb{R}^{hd\_k}$ into the final output $\boldsymbol{y}\in\mathbb{R}^{d\_k}=\boldsymbol{z}^TW^O$. That's quite a number of vectors, matrices and dimensions to juggle around in you head so hopefully the following visualization helps to clarify the concept.
 
-<img class="img-animate" src="https://assets.hummat.com/images/attention/multi_head_attention.png">
+<img class="img-animate" src="https://assets.hummat.com/images/attention/multi_head_attention.png" alt="Animated multi-head attention: inputs projected through stacked Q, K, V matrices for two heads, combined via output matrix">
 
 In the illustration above we have two input vectors, $\boldsymbol{x}\_1$ and $\boldsymbol{x}\_2$, both of size $\mathbb{R}^{4\times1}$ stacked into an input matrix (row-wise) of size $X\in\mathbb{R}^{2\times4}$. We transform the inputs using two attention heads ($h=2$) with parameter matrices $W\_i^Q$, $W\_i^K$ and $W\_i^V$ with $i\in[1,2]$ all of size $\mathbb{R}^{4\times3}$. Through stacking of the query, key and value matrices (column-wise) from both heads we obtain three matrices of size $\mathbb{R}^{4\times6}$. We can now multiply the input matrix with the query, key and value matrices of both heads simultaneously and compute an intermediate output matrix $Z\in\mathbb{R}^{2\times6}$ using the dot product between our two-head query and key matrix and multiplying the result with our two-head value matrix. Finally, to transform the intermediate output $Z$ into the final output $Y\in\mathbb{R}^{2\times3}$, we apply the output weight matrix $W^O\in\mathbb{R}^{6\times3}$.
 
@@ -238,7 +238,7 @@ To wrap things up, let's try to put attention into a broader context. In particu
 
 In the case of convolutional layers multi-head attention can be interpreted as a generalization of discrete convolution. Given a convolutional kernel $W\in\mathbb{R}^{k\times k}$ placed on the $i^{th}$ input element we now use $h=k^2$ heads and attention weights $w_{ij}=1$ if $j=i\pm (k^2-1)/2$. This means we only consider keys which are within kernel size distance to the query where the query corresponds to the center of the kernel. With $W^V=I$ the output matrix $W^O$ then corresponds to the convolutional kernel. As the explanation is a little convoluted itself have a look at the visualization below for some intuition.
 
-<img class="img-animate" src="https://assets.hummat.com/images/attention/conv.png">
+<img class="img-animate" src="https://assets.hummat.com/images/attention/conv.png" alt="Animated comparison showing how multi-head attention generalizes discrete convolution">
 
 ## Credits
 

--- a/_posts/2021-06-29-deep-learning-on-synthetic-data.md
+++ b/_posts/2021-06-29-deep-learning-on-synthetic-data.md
@@ -26,7 +26,7 @@ Now, if you are reading this, chances are you are neither a cinematographer nor 
 
 <div style="text-align: center">
 <figure style="width: 90%; display: inline-block;">
-  <img class="img-swap" src="https://assets.hummat.com/images/cup/coco.jpg">
+  <img class="img-swap" src="https://assets.hummat.com/images/cup/coco.jpg" alt="Living room scene with instance segmentation masks overlaid on objects; hover to toggle masks">
   <figcaption style="text-align: left; line-height: 1.5em;"><b>Instance Segmentation:</b> Every <em>pixel</em> of every <em>instance</em> of each object, e.g. <em>couch</em> or <em>chair</em>, needs to be labeled in every image. The resulting <em>instance segmentation masks</em> can be visualized as semi-transparent overlays (hover over the image to see them). This insane amount of work leads to imperfect results: Only a subset of all visible objects gets labeled, not all instances get labeled (one of the two vases in the bookshelf is missing) or are lumped together (lower rows of books in the shelf), masks are not pixel-perfect (the light blue mask of the arm-chair) and objects get wrong labels (the fireplace is labeled as tv, the armchair in front is also labeled as couch).</figcaption>
 </figure>
 </div>
@@ -55,22 +55,22 @@ We could now snap an artificial image (i.e. a _render_) of the cup model to get 
 
 <div id="slideshow1" class="slideshow-container">
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/cup_basic.png" style="width: 100%">
+  <img src="https://assets.hummat.com/images/cup/cup_basic.png" style="width: 100%" alt="Rendered cup model without colors or textures">
   <div class="text"><b>The bare minimum:</b> The rendered cup wihtout colors, textures and surface properties.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/cup_color.png" style="width: 100%">
+  <img src="https://assets.hummat.com/images/cup/cup_color.png" style="width: 100%" alt="Rendered cup with correct colors and reflections">
   <div class="text"><b>Color and reflections:</b> Correct colors and roughness greatly increase realism.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/cup_texture.png" style="width: 100%">
+  <img src="https://assets.hummat.com/images/cup/cup_texture.png" style="width: 100%" alt="Rendered cup with textures, displacements, and surface imperfections">
   <div class="text"><b>Adding subtle effects:</b> Textures, displacements and surface imperfections.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/cup_background.jpg" style="width: 100%">
+  <img src="https://assets.hummat.com/images/cup/cup_background.jpg" style="width: 100%" alt="Photorealistic rendered cup on a random background with correct lighting">
   <div class="text"><b>Final result:</b>The cup rendered on a random background with correct lighting.</div>
   </div>
 
@@ -85,27 +85,27 @@ While simple, the result is unconvincing due to differences in lighting: the obj
 
 <div id="slideshow2" class="slideshow-container">
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/basic/rgb_0051.jpg">
+  <img src="https://assets.hummat.com/images/cup/basic/rgb_0051.jpg" alt="Cup rendered from a random viewpoint with HDRI background lighting">
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/basic/rgb_0053.jpg">
+  <img src="https://assets.hummat.com/images/cup/basic/rgb_0053.jpg" alt="Cup rendered from a random viewpoint with HDRI background lighting">
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/basic/rgb_0054.jpg">
+  <img src="https://assets.hummat.com/images/cup/basic/rgb_0054.jpg" alt="Cup rendered from a random viewpoint with HDRI background lighting">
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/basic/rgb_0062.jpg">
+  <img src="https://assets.hummat.com/images/cup/basic/rgb_0062.jpg" alt="Cup rendered from a random viewpoint with HDRI background lighting">
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/basic/rgb_0063.jpg">
+  <img src="https://assets.hummat.com/images/cup/basic/rgb_0063.jpg" alt="Cup rendered from a random viewpoint with HDRI background lighting">
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/basic/rgb_0064.jpg">
+  <img src="https://assets.hummat.com/images/cup/basic/rgb_0064.jpg" alt="Cup rendered from a random viewpoint with HDRI background lighting">
   </div>
 
 <a class="prev" data-slide-step="-1">&#10094;</a>
@@ -127,23 +127,23 @@ This is what BlenderProc builds on to provide functions to place objects, lights
 
 <div id="slideshow3" class="slideshow-container">
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/room/rgb_0000.jpg">
+    <img src="https://assets.hummat.com/images/cup/room/rgb_0000.jpg" alt="Cup in a virtual room with random lighting and reflections">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/room/rgb_0001.jpg">
+    <img src="https://assets.hummat.com/images/cup/room/rgb_0001.jpg" alt="Cup in a virtual room with random lighting and reflections">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/room/rgb_0002.jpg">
+    <img src="https://assets.hummat.com/images/cup/room/rgb_0002.jpg" alt="Cup in a virtual room with random lighting and reflections">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/room/rgb_0003.jpg">
+    <img src="https://assets.hummat.com/images/cup/room/rgb_0003.jpg" alt="Cup in a virtual room with random lighting and reflections">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/room/rgb_0004.jpg">
+    <img src="https://assets.hummat.com/images/cup/room/rgb_0004.jpg" alt="Cup in a virtual room with random lighting and reflections">
   </div>
 
 <a class="prev" data-slide-step="-1">&#10094;</a>
@@ -161,23 +161,23 @@ Here is a little entertaining anecdote: Do you see how the cup stands tilted to 
 
 <div id="slideshow4" class="slideshow-container">
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/pose/rgb_0000.jpg">
+    <img src="https://assets.hummat.com/images/cup/pose/rgb_0000.jpg" alt="Cup in a physically simulated pose after dropping into the scene">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/pose/rgb_0001.jpg">
+    <img src="https://assets.hummat.com/images/cup/pose/rgb_0001.jpg" alt="Cup in a physically simulated pose after dropping into the scene">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/pose/rgb_0002.jpg">
+    <img src="https://assets.hummat.com/images/cup/pose/rgb_0002.jpg" alt="Cup in a physically simulated pose after dropping into the scene">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/pose/rgb_0003.jpg">
+    <img src="https://assets.hummat.com/images/cup/pose/rgb_0003.jpg" alt="Cup in a physically simulated pose after dropping into the scene">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/pose/rgb_0004.jpg">
+    <img src="https://assets.hummat.com/images/cup/pose/rgb_0004.jpg" alt="Cup in a physically simulated pose after dropping into the scene">
   </div>
 
 <a class="prev" data-slide-step="-1">&#10094;</a>
@@ -189,23 +189,23 @@ Another problem you might have noticed is the white background. Detecting object
 
 <div id="slideshow5" class="slideshow-container">
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/textures/rgb_0000.jpg">
+    <img src="https://assets.hummat.com/images/cup/textures/rgb_0000.jpg" alt="Cup in a room with randomized PBR textures on walls and floor">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/textures/rgb_0001.jpg">
+    <img src="https://assets.hummat.com/images/cup/textures/rgb_0001.jpg" alt="Cup in a room with randomized PBR textures on walls and floor">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/textures/rgb_0002.jpg">
+    <img src="https://assets.hummat.com/images/cup/textures/rgb_0002.jpg" alt="Cup in a room with randomized PBR textures on walls and floor">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/textures/rgb_0003.jpg">
+    <img src="https://assets.hummat.com/images/cup/textures/rgb_0003.jpg" alt="Cup in a room with randomized PBR textures on walls and floor">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/textures/rgb_0004.jpg">
+    <img src="https://assets.hummat.com/images/cup/textures/rgb_0004.jpg" alt="Cup in a room with randomized PBR textures on walls and floor">
   </div>
 
 <a class="prev" data-slide-step="-1">&#10094;</a>
@@ -217,23 +217,23 @@ Next, we introduce clutter. Due to shadows and sudden changes in color and other
 
 <div id="slideshow6" class="slideshow-container">
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/clutter/rgb_0000.jpg">
+    <img src="https://assets.hummat.com/images/cup/clutter/rgb_0000.jpg" alt="Cup among random clutter objects with textured surfaces">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/clutter/rgb_0001.jpg">
+    <img src="https://assets.hummat.com/images/cup/clutter/rgb_0001.jpg" alt="Cup among random clutter objects with textured surfaces">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/clutter/rgb_0002.jpg">
+    <img src="https://assets.hummat.com/images/cup/clutter/rgb_0002.jpg" alt="Cup among random clutter objects with textured surfaces">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/clutter/rgb_0003.jpg">
+    <img src="https://assets.hummat.com/images/cup/clutter/rgb_0003.jpg" alt="Cup among random clutter objects with textured surfaces">
   </div>
 
   <div class="mySlides">
-    <img src="https://assets.hummat.com/images/cup/clutter/rgb_0004.jpg">
+    <img src="https://assets.hummat.com/images/cup/clutter/rgb_0004.jpg" alt="Cup among random clutter objects with textured surfaces">
   </div>
 
 <a class="prev" data-slide-step="-1">&#10094;</a>
@@ -262,23 +262,23 @@ With this you will get results like the ones seen below.
 
 <div id="slideshow7" class="slideshow-container">
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/scene/rgb_0000.jpg">
+  <img src="https://assets.hummat.com/images/cup/scene/rgb_0000.jpg" alt="Cup placed in a photorealistic 3D-FRONT room with furniture">
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/scene/rgb_0001.jpg">
+  <img src="https://assets.hummat.com/images/cup/scene/rgb_0001.jpg" alt="Cup placed in a photorealistic 3D-FRONT room with furniture">
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/scene/rgb_0002.jpg">
+  <img src="https://assets.hummat.com/images/cup/scene/rgb_0002.jpg" alt="Cup placed in a photorealistic 3D-FRONT room with furniture">
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/scene/rgb_0003.jpg">
+  <img src="https://assets.hummat.com/images/cup/scene/rgb_0003.jpg" alt="Cup placed in a photorealistic 3D-FRONT room with furniture">
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/scene/rgb_0004.jpg">
+  <img src="https://assets.hummat.com/images/cup/scene/rgb_0004.jpg" alt="Cup placed in a photorealistic 3D-FRONT room with furniture">
   </div>
 
 <a class="prev" data-slide-step="-1">&#10094;</a>
@@ -290,22 +290,22 @@ When saving the render, we have the option to not only store the color image, bu
 
 <div id="slideshow8" class="slideshow-container">
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/dataset/Figure_2.png" style="width:100%;">
+  <img src="https://assets.hummat.com/images/cup/dataset/Figure_2.png" style="width:100%;" alt="Rendered color image of the cup lying on its side in a cluttered scene">
   <div class="text"><b>RGB:</b> The rendered color image with the cup lying off-center on its side. There are lots of textures and clutter as well as realistic reflections, shadows, occlusion and depth of field effects.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/dataset/Figure_3.png" style="width:100%;">
+  <img src="https://assets.hummat.com/images/cup/dataset/Figure_3.png" style="width:100%;" alt="Depth map of the scene with blue for near and red for far">
   <div class="text"><b>Depth:</b> Because our scene consists of actual 3D objects and Blender needs to know each of their positions to present the scene on a 2D surface (your monitor) we can also store this information in a depth map with colors encoding the distance to the camera where blue means near and red far away. Such information can't even be generated by human annotators retrospectively but has to be captured with (inaccruate) depth sensors in reality.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/dataset/Figure_4.png" style="width:100%;">
+  <img src="https://assets.hummat.com/images/cup/dataset/Figure_4.png" style="width:100%;" alt="Surface normal map with orientation encoded as RGB colors">
   <div class="text"><b>Normals:</b> The orientation of a surface can be represented by its normal which is a perpendicular vector with x, y and z coordinates. We can interpret those coordinates as red, green and blue color values for visualization where surfaces with the same orientation have the same color.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/dataset/Figure_6.png" style="width:100%;">
+  <img src="https://assets.hummat.com/images/cup/dataset/Figure_6.png" style="width:100%;" alt="Pixel-perfect semantic segmentation mask highlighting the cup">
   <div class="text"><b>Segmentation:</b> Finally, and most importantly for our application, we can obtain pixel perfect semantic segmentation masks. They look a bit boring in our case as there is only a single object of interest while everything else is considered background. Instance segmentation masks can also be generated if needed.</div>
   </div>
 
@@ -322,57 +322,57 @@ Training takes only a couple of minutes on this small dataset (though longer tra
 
 <div id="slideshow9" class="slideshow-container">
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/real/real0.jpg">
+  <img src="https://assets.hummat.com/images/cup/real/real0.jpg" alt="Real photograph with detected cup showing bounding box and segmentation mask">
   <div class="text"><b>The Cup:</b> Success! Our network trained purely on synthetic images is able to detect objects in the real world. Even after some time now this is still somewhat miraculous to me. As you can see, the bounding box and segmentation mask isn't perfect but pretty good.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/real/real1.jpg">
+  <img src="https://assets.hummat.com/images/cup/real/real1.jpg" alt="Two cups detected with individual instance segmentation masks">
   <div class="text"><b>Two Cups:</b> Two cups work as well even though the training data never contained more than one cup per image. Also note that we perform <em>instance segmentation</em> where each instance of an object is segmented individually.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/real/real2.jpg">
+  <img src="https://assets.hummat.com/images/cup/real/real2.jpg" alt="Upside-down cup correctly detected and segmented">
   <div class="text"><b>Upside down:</b> Turning the cup on its head doesn't pose a problem to our model as it has seen the cup from all directions during training.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/real/real3.jpg">
+  <img src="https://assets.hummat.com/images/cup/real/real3.jpg" alt="Two cups with one occluding the other, both correctly detected">
   <div class="text" style="text-align: left; line-height: 1.5em; bottom: -4em; width: 90%;"><b>Occlusion:</b> Even though both cups don't even touch in 3D space, one occludes the other in this 2D view. No problem though.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/real/real4.jpg">
+  <img src="https://assets.hummat.com/images/cup/real/real4.jpg" alt="Two stacked cups incorrectly detected as a single cup">
   <div class="text"><b>Stacking:</b> The first failure case: Stacking two cups gets interpreted as a single cup. Adding such cases to the training data could help here.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/real/real5.jpg">
+  <img src="https://assets.hummat.com/images/cup/real/real5.jpg" alt="Cup correctly detected among several dissimilar clutter objects">
   <div class="text"><b>Clutter:</b> To make the task a little more difficult, we can add several dissimilar objects to the scene. This was the default setting during training so it's not surprising for our model to pass this test with flying colors.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/real/real6.jpg">
+  <img src="https://assets.hummat.com/images/cup/real/real6.jpg" alt="Cup detected among closely placed clutter objects">
   <div class="text" style="text-align: left; line-height: 1.5em; bottom: -4em; width: 90%;"><b>Close clutter:</b> Moving everything closer together makes the task a little harder but apparently not too much.</div>
   </div>
   
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/real/real7.jpg">
+  <img src="https://assets.hummat.com/images/cup/real/real7.jpg" alt="False positive: cup-like object incorrectly detected as the target cup">
   <div class="text"><b>Another configuration:</b> Another failure: It looks like as if the model generalizes a little far to any cup-like object. Let's investigate.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/real/real8.jpg">
+  <img src="https://assets.hummat.com/images/cup/real/real8.jpg" alt="Over-generalization: multiple cup-like objects falsely detected">
   <div class="text"><b>Too much generalization:</b> Indeed. While we certainly didn't overfit on the cup, this amount of generalization might not be what you want. Longer training on more data and the introduction of more negative cup-like objects should help.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/real/real9.jpg">
+  <img src="https://assets.hummat.com/images/cup/real/real9.jpg" alt="Bowls incorrectly classified as cups showing over-generalization">
   <div class="text"><b>Cups and bowls:</b> Even bowls get classified as cups. Oh well.</div>
   </div>
 
   <div class="mySlides">
-  <img src="https://assets.hummat.com/images/cup/real/real10.jpg">
+  <img src="https://assets.hummat.com/images/cup/real/real10.jpg" alt="Large pile of objects with cup-like ones falsely detected">
   <div class="text"><b>Mess:</b> Throwing a large pile of different things together reveals the (over) generalization capabilities of our model on cup-like objects while very different objects get ignored as desired.</div>
   </div>
 

--- a/_posts/2021-06-29-deep-learning-on-synthetic-data.md
+++ b/_posts/2021-06-29-deep-learning-on-synthetic-data.md
@@ -37,7 +37,7 @@ How do we get training data for these tasks? Well, depending at where you work a
 
 Apart from fatiguing fellow human beings by forcing them to do such boring work, they also get tired and make mistakes resulting in wrong class labels, too large or small bounding boxes and forgotten objects. You probably see where this is going: What if we could automate this task by generating training data with pixel-perfect annotations in huge quantities? Let's explore the potential and accompanying difficulties of this idea through a running example: _The cup_.
 
-![](https://assets.hummat.com/images/cup/cup_photo.jpg)
+![Photograph of the cup used as running example throughout this article](https://assets.hummat.com/images/cup/cup_photo.jpg)
 
 By the end of this article, we want to be able to detect the occurrence and position of this cup in real photographs (and maybe even do segmentation and pose estimation) without hand-annotating even a single training datum.
 


### PR DESCRIPTION
## Summary
- Add meaningful `alt` attributes to all 113 `<img>` tags across 12 posts and `ASSETS.md`
- Alt text derived from figcaptions, filenames, and surrounding prose context
- Animated/interactive images note their behavior in alt text
- Decorative or code-example images handled appropriately

Closes #7

## Test plan
- [x] `bundle exec jekyll build` — clean, no errors
- [x] 0 missing `alt` attributes in built `_site/` output
- [x] Pre-commit hooks (markdownlint, prettier) pass
- [ ] Spot-check rendered posts for sensible alt text on hover/screen reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)