### PR TITLE
Harden formatting scope and issue auto-close guard

### DIFF
--- a/.github/workflows/close-issues-on-merge.yml
+++ b/.github/workflows/close-issues-on-merge.yml
@@ -48,6 +48,11 @@ jobs:
                   issue_number: issueNumber
                 });
 
+                if (issue.pull_request) {
+                  console.log(`Skipping #${issueNumber}: reference is a pull request`);
+                  continue;
+                }
+
                 if (issue.state === 'open') {
                   await github.rest.issues.update({
                     owner: context.repo.owner,

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,6 @@
 .claude/
+.mcp.json
+.playwright/
 _site/
 node_modules/
 figures/


### PR DESCRIPTION
## Summary

- Exclude local, gitignored MCP/Playwright config from Prettier checks
- Prevent close-issues workflow from closing pull-request references
- Keep scope to tooling/automation hardening only

Closes: #86

## Type of Change

- [ ] Content fix (typo, broken link, factual error)
- [ ] New post
- [x] Site improvement (layout, styling, functionality)
- [ ] Other

## Checklist

- [x] PR targets `netlify` branch (not `main`)
- [ ] Tested locally with `bundle exec jekyll serve`
- [ ] Site builds without errors (`bundle exec jekyll build`)
- [ ] Screenshots attached (for visual changes)

## Verification

- `npm run format:check` ✅
- `npm run test:workflow-scripts` ✅