### PR TITLE
Replace Disqus with consent-gated utterances comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,9 +45,17 @@ footer-links:
   youtube: # channel/<your_long_string> or user/<user-name>
   googleplus: # anything in your profile username that comes after plus.google.com/
 
-# Enter your Disqus shortname (not your username) to enable commenting on posts
-# You can find your shortname on the Settings page of your Disqus account
-disqus: hummat-github-io
+# Comments provider configuration.
+# Supported provider:
+# - utterances (GitHub Issues-based comments)
+comments:
+  provider: utterances
+
+utterances:
+  repo: hummat/hummat.github.io
+  issue_term: pathname
+  label: comments
+  theme: preferred-color-scheme
 
 # Enter your Google Analytics GA4 measurement ID (e.g. G-XXXXXXXXXX) to activate tracking.
 # Leave empty to disable analytics.

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,0 +1,13 @@
+{% if page.comments != false %} {% assign comments_provider = site.comments.provider | default: ""
+%} {% if comments_provider == "utterances" and site.utterances.repo %}
+<div class="comments noprint">
+  <div
+    id="utterances_thread"
+    data-utterances-repo="{{ site.utterances.repo | escape }}"
+    data-utterances-issue-term="{{ site.utterances.issue_term | default: 'pathname' | escape }}"
+    data-utterances-label="{{ site.utterances.label | default: '' | escape }}"
+    data-utterances-theme="{{ site.utterances.theme | default: 'preferred-color-scheme' | escape }}"
+  ></div>
+  <noscript>Please enable JavaScript to view comments.</noscript>
+</div>
+{% endif %} {% endif %}

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,12 +1,30 @@
 {% if page.comments != false %} {% assign comments_provider = site.comments.provider | default: ""
 %} {% if comments_provider == "utterances" and site.utterances.repo %}
 <div class="comments noprint">
+  <div id="comments-consent-gate" class="comments-consent-gate">
+    <p>
+      Comments are powered by GitHub (utterances) and load third-party content from
+      <code>utteranc.es</code>. Click to load comments.
+    </p>
+    <div class="comments-consent-actions">
+      <button type="button" data-comments-action="accept">Load comments</button>
+    </div>
+  </div>
+
+  <p id="comments-consent-manage" class="comments-consent-manage" hidden>
+    Comments are loaded.
+    <button type="button" class="comments-link-button" data-comments-action="revoke">
+      Disable comments
+    </button>
+  </p>
+
   <div
     id="utterances_thread"
     data-utterances-repo="{{ site.utterances.repo | escape }}"
     data-utterances-issue-term="{{ site.utterances.issue_term | default: 'pathname' | escape }}"
     data-utterances-label="{{ site.utterances.label | default: '' | escape }}"
     data-utterances-theme="{{ site.utterances.theme | default: 'preferred-color-scheme' | escape }}"
+    hidden
   ></div>
   <noscript>Please enable JavaScript to view comments.</noscript>
 </div>

--- a/_includes/cookie-consent.html
+++ b/_includes/cookie-consent.html
@@ -1,7 +1,5 @@
 <div id="cookie-consent-banner" class="cookie-consent noprint" hidden>
-  <p>
-    This site can load optional third-party services (comments and Google Analytics). Allow them?
-  </p>
+  <p>This site can load optional Google Analytics measurement. Allow analytics?</p>
   <div class="cookie-consent-actions">
     <button type="button" data-consent-action="accept">Allow</button>
     <button type="button" data-consent-action="decline">Decline</button>

--- a/_includes/cookie-consent.html
+++ b/_includes/cookie-consent.html
@@ -1,7 +1,6 @@
 <div id="cookie-consent-banner" class="cookie-consent noprint" hidden>
   <p>
-    This site can load optional third-party services (Disqus comments and Google Analytics). Allow
-    them?
+    This site can load optional third-party services (comments and Google Analytics). Allow them?
   </p>
   <div class="cookie-consent-actions">
     <button type="button" data-consent-action="accept">Allow</button>

--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -1,9 +1,0 @@
-{% if site.disqus and page.comments != false %}
-<div class="comments noprint">
-  <div id="disqus_thread" data-disqus-shortname="{{ site.disqus | escape }}"></div>
-  <noscript
-    >Please enable JavaScript to view the
-    <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript
-  >
-</div>
-{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,5 +13,5 @@ layout: default
     <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %e, %Y" }}</time>
     {% endif %}
   </div>
-  {% include disqus.html %}
+  {% include comments.html %}
 </article>

--- a/assets/js/privacy-consent.js
+++ b/assets/js/privacy-consent.js
@@ -52,30 +52,41 @@
     window.gtag("config", analyticsId);
   }
 
-  function loadDisqus(shortname) {
-    if (!shortname || document.getElementById("disqus-embed-loader")) {
+  function loadUtterances(thread) {
+    if (!thread || document.getElementById("utterances-embed-loader")) {
       return;
     }
 
-    const dsq = document.createElement("script");
-    dsq.id = "disqus-embed-loader";
-    dsq.type = "text/javascript";
-    dsq.async = true;
-    dsq.src = `https://${shortname}.disqus.com/embed.js`;
-    dsq.setAttribute("data-timestamp", String(Date.now()));
+    const repo = (thread.getAttribute("data-utterances-repo") || "").trim();
+    if (!repo) {
+      return;
+    }
 
-    (document.head || document.body).appendChild(dsq);
+    const issueTerm = (thread.getAttribute("data-utterances-issue-term") || "pathname").trim();
+    const label = (thread.getAttribute("data-utterances-label") || "").trim();
+    const theme = (thread.getAttribute("data-utterances-theme") || "preferred-color-scheme").trim();
+
+    const script = document.createElement("script");
+    script.id = "utterances-embed-loader";
+    script.src = "https://utteranc.es/client.js";
+    script.async = true;
+    script.setAttribute("repo", repo);
+    script.setAttribute("issue-term", issueTerm);
+    if (label) {
+      script.setAttribute("label", label);
+    }
+    script.setAttribute("theme", theme);
+    script.setAttribute("crossorigin", "anonymous");
+
+    thread.appendChild(script);
   }
 
   function applyOptionalServices() {
     const analyticsId = getAnalyticsId();
-    const disqusThread = document.getElementById("disqus_thread");
-    const disqusShortname = disqusThread
-      ? (disqusThread.getAttribute("data-disqus-shortname") || "").trim()
-      : "";
+    const utterancesThread = document.getElementById("utterances_thread");
 
     loadAnalytics(analyticsId);
-    loadDisqus(disqusShortname);
+    loadUtterances(utterancesThread);
   }
 
   function initConsentBanner() {
@@ -85,8 +96,8 @@
     }
 
     const analyticsId = getAnalyticsId();
-    const disqusThread = document.getElementById("disqus_thread");
-    const hasOptionalServices = Boolean(analyticsId || disqusThread);
+    const utterancesThread = document.getElementById("utterances_thread");
+    const hasOptionalServices = Boolean(analyticsId || utterancesThread);
 
     if (!hasOptionalServices) {
       return;

--- a/assets/js/privacy-consent.js
+++ b/assets/js/privacy-consent.js
@@ -2,20 +2,21 @@
   "use strict";
 
   const CONSENT_KEY = "hummat-cookie-consent-v1";
+  const COMMENTS_CONSENT_KEY = "hummat-comments-consent-v1";
   const CONSENT_ACCEPTED = "accepted";
   const CONSENT_DECLINED = "declined";
 
-  function readConsent() {
+  function readPreference(key) {
     try {
-      return localStorage.getItem(CONSENT_KEY);
+      return localStorage.getItem(key);
     } catch (_err) {
       return null;
     }
   }
 
-  function writeConsent(value) {
+  function writePreference(key, value) {
     try {
-      localStorage.setItem(CONSENT_KEY, value);
+      localStorage.setItem(key, value);
     } catch (_err) {
       // Ignore storage failures.
     }
@@ -52,6 +53,26 @@
     window.gtag("config", analyticsId);
   }
 
+  function removeUtterances(thread) {
+    if (!thread) {
+      return;
+    }
+
+    const embeddedElements = thread.querySelectorAll(
+      "script#utterances-embed-loader, iframe.utterances-frame"
+    );
+    embeddedElements.forEach((element) => {
+      element.remove();
+    });
+
+    const detachedFrames = document.querySelectorAll("iframe.utterances-frame");
+    detachedFrames.forEach((frame) => {
+      frame.remove();
+    });
+
+    thread.hidden = true;
+  }
+
   function loadUtterances(thread) {
     if (!thread || document.getElementById("utterances-embed-loader")) {
       return;
@@ -78,15 +99,80 @@
     script.setAttribute("theme", theme);
     script.setAttribute("crossorigin", "anonymous");
 
+    thread.hidden = false;
     thread.appendChild(script);
   }
 
-  function applyOptionalServices() {
-    const analyticsId = getAnalyticsId();
-    const utterancesThread = document.getElementById("utterances_thread");
+  function setCommentsUiState({ loaded, gate, manage, thread }) {
+    if (gate) {
+      gate.hidden = loaded;
+    }
 
-    loadAnalytics(analyticsId);
-    loadUtterances(utterancesThread);
+    if (manage) {
+      manage.hidden = !loaded;
+    }
+
+    if (thread) {
+      thread.hidden = !loaded;
+    }
+  }
+
+  function initCommentsConsent() {
+    const thread = document.getElementById("utterances_thread");
+    if (!thread) {
+      return;
+    }
+
+    const commentsRoot = thread.closest(".comments");
+    const gate = document.getElementById("comments-consent-gate");
+    const manage = document.getElementById("comments-consent-manage");
+    if (!commentsRoot || !gate) {
+      return;
+    }
+
+    const commentsConsent = readPreference(COMMENTS_CONSENT_KEY);
+    const shouldLoadComments = commentsConsent === CONSENT_ACCEPTED;
+
+    setCommentsUiState({
+      loaded: shouldLoadComments,
+      gate,
+      manage,
+      thread,
+    });
+
+    if (shouldLoadComments) {
+      loadUtterances(thread);
+    } else {
+      removeUtterances(thread);
+    }
+
+    commentsRoot.addEventListener("click", (event) => {
+      const actionButton = event.target.closest("button[data-comments-action]");
+      if (!actionButton) {
+        return;
+      }
+
+      const action = actionButton.getAttribute("data-comments-action");
+      if (action === "accept") {
+        writePreference(COMMENTS_CONSENT_KEY, CONSENT_ACCEPTED);
+        setCommentsUiState({
+          loaded: true,
+          gate,
+          manage,
+          thread,
+        });
+        loadUtterances(thread);
+      } else if (action === "revoke") {
+        writePreference(COMMENTS_CONSENT_KEY, CONSENT_DECLINED);
+        removeUtterances(thread);
+        setCommentsUiState({
+          loaded: false,
+          gate,
+          manage,
+          thread,
+        });
+      }
+    });
   }
 
   function initConsentBanner() {
@@ -96,16 +182,15 @@
     }
 
     const analyticsId = getAnalyticsId();
-    const utterancesThread = document.getElementById("utterances_thread");
-    const hasOptionalServices = Boolean(analyticsId || utterancesThread);
+    const hasAnalytics = Boolean(analyticsId);
 
-    if (!hasOptionalServices) {
+    if (!hasAnalytics) {
       return;
     }
 
-    const consent = readConsent();
+    const consent = readPreference(CONSENT_KEY);
     if (consent === CONSENT_ACCEPTED) {
-      applyOptionalServices();
+      loadAnalytics(analyticsId);
       return;
     }
 
@@ -121,19 +206,24 @@
 
       const action = actionButton.getAttribute("data-consent-action");
       if (action === "accept") {
-        writeConsent(CONSENT_ACCEPTED);
-        applyOptionalServices();
+        writePreference(CONSENT_KEY, CONSENT_ACCEPTED);
+        loadAnalytics(analyticsId);
       } else if (action === "decline") {
-        writeConsent(CONSENT_DECLINED);
+        writePreference(CONSENT_KEY, CONSENT_DECLINED);
       }
 
       banner.hidden = true;
     });
   }
 
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", initConsentBanner);
-  } else {
+  function initPrivacyControls() {
     initConsentBanner();
+    initCommentsConsent();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initPrivacyControls);
+  } else {
+    initPrivacyControls();
   }
 })();

--- a/docs/agent/architecture.md
+++ b/docs/agent/architecture.md
@@ -33,7 +33,7 @@
 
 - **Posts**: `_posts/YYYY-MM-DD-kebab-title.md` with YAML front matter
 - **Drafts**: `_drafts/slug.md` (no date prefix); preview with `--drafts`
-- **Config**: `_config.yml` for site metadata, plugins, analytics, Disqus
+- **Config**: `_config.yml` for site metadata, plugins, analytics, comments provider
 - **Assets**: stored in Cloudflare R2; see `ASSETS.md`
 
 ## Key Files

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   for = "/*"
 
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://code.jquery.com https://cdn.plot.ly https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://www.googletagmanager.com https://*.disqus.com https://*.disquscdn.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.semanticscholar.org https://assets.hummat.com https://www.google-analytics.com https://region1.google-analytics.com https://*.disqus.com https://*.disquscdn.com; frame-src 'self' https://assets.hummat.com https://disqus.com https://*.disqus.com https://*.disquscdn.com; font-src 'self' data: https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://code.jquery.com https://cdn.plot.ly https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://www.googletagmanager.com https://utteranc.es; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://api.semanticscholar.org https://assets.hummat.com https://www.google-analytics.com https://region1.google-analytics.com; frame-src 'self' https://assets.hummat.com https://utteranc.es; font-src 'self' data: https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests"
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"

--- a/style.scss
+++ b/style.scss
@@ -222,6 +222,40 @@ article p {
   background: #ececec;
 }
 
+.comments-consent-gate {
+  border: 1px solid #d9d9d9;
+  background: #fafafa;
+  padding: 0.8rem 0.9rem;
+  margin-bottom: 0.75rem;
+}
+
+.comments-consent-gate p {
+  margin: 0 0 0.65rem;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.comments-consent-manage {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  color: #666;
+}
+
+.comments-link-button {
+  margin-left: 0.35rem;
+  border: 0;
+  background: none;
+  color: $blue;
+  font: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}
+
+.comments-link-button:hover {
+  color: darken($blue, 10%);
+}
+
 .tags .tag {
   display: inline-block;
   color: rgba(0, 0, 0, 0.67);

--- a/tests/js/privacy-consent.test.js
+++ b/tests/js/privacy-consent.test.js
@@ -2,7 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const { createDom, runBrowserScript, flushMicrotasks } = require("./test-utils");
 
-test("consent banner loads analytics and Disqus only after accept", async () => {
+test("consent banner loads analytics and utterances only after accept", async () => {
   const dom = createDom({
     headHtml: '<meta name="google-analytics-id" content="G-TEST1234">',
     bodyHtml:
@@ -10,7 +10,7 @@ test("consent banner loads analytics and Disqus only after accept", async () => 
       '<button type="button" data-consent-action="accept">Accept</button>' +
       '<button type="button" data-consent-action="decline">Decline</button>' +
       "</div>" +
-      '<div id="disqus_thread" data-disqus-shortname="hummat-github-io"></div>',
+      '<div id="utterances_thread" data-utterances-repo="hummat/hummat.github.io" data-utterances-issue-term="pathname" data-utterances-label="comments" data-utterances-theme="preferred-color-scheme"></div>',
   });
   Object.defineProperty(dom.window.document, "readyState", {
     configurable: true,
@@ -23,7 +23,7 @@ test("consent banner loads analytics and Disqus only after accept", async () => 
   const banner = dom.window.document.getElementById("cookie-consent-banner");
   assert.equal(banner.hidden, false);
   assert.equal(dom.window.document.getElementById("ga4-loader"), null);
-  assert.equal(dom.window.document.getElementById("disqus-embed-loader"), null);
+  assert.equal(dom.window.document.getElementById("utterances-embed-loader"), null);
 
   const acceptButton = banner.querySelector('[data-consent-action="accept"]');
   acceptButton.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
@@ -32,10 +32,14 @@ test("consent banner loads analytics and Disqus only after accept", async () => 
   assert.equal(dom.window.localStorage.getItem("hummat-cookie-consent-v1"), "accepted");
 
   const gaScript = dom.window.document.getElementById("ga4-loader");
-  const disqusScript = dom.window.document.getElementById("disqus-embed-loader");
+  const utterancesScript = dom.window.document.getElementById("utterances-embed-loader");
   assert.ok(gaScript);
-  assert.ok(disqusScript);
+  assert.ok(utterancesScript);
   assert.match(gaScript.src, /googletagmanager\.com/);
-  assert.match(disqusScript.src, /hummat-github-io\.disqus\.com\/embed\.js/);
+  assert.match(utterancesScript.src, /utteranc\.es\/client\.js/);
+  assert.equal(utterancesScript.getAttribute("repo"), "hummat/hummat.github.io");
+  assert.equal(utterancesScript.getAttribute("issue-term"), "pathname");
+  assert.equal(utterancesScript.getAttribute("label"), "comments");
+  assert.equal(utterancesScript.getAttribute("theme"), "preferred-color-scheme");
   assert.equal(banner.hidden, true);
 });

--- a/tests/js/privacy-consent.test.js
+++ b/tests/js/privacy-consent.test.js
@@ -2,7 +2,21 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const { createDom, runBrowserScript, flushMicrotasks } = require("./test-utils");
 
-test("consent banner loads analytics and utterances only after accept", async () => {
+function commentsFixtureHtml() {
+  return (
+    '<div class="comments">' +
+    '<div id="comments-consent-gate">' +
+    '<button type="button" data-comments-action="accept">Load comments</button>' +
+    "</div>" +
+    '<p id="comments-consent-manage" hidden>' +
+    '<button type="button" data-comments-action="revoke">Disable comments</button>' +
+    "</p>" +
+    '<div id="utterances_thread" data-utterances-repo="hummat/hummat.github.io" data-utterances-issue-term="pathname" data-utterances-label="comments" data-utterances-theme="preferred-color-scheme" hidden></div>' +
+    "</div>"
+  );
+}
+
+test("cookie banner controls analytics only", async () => {
   const dom = createDom({
     headHtml: '<meta name="google-analytics-id" content="G-TEST1234">',
     bodyHtml:
@@ -10,7 +24,7 @@ test("consent banner loads analytics and utterances only after accept", async ()
       '<button type="button" data-consent-action="accept">Accept</button>' +
       '<button type="button" data-consent-action="decline">Decline</button>' +
       "</div>" +
-      '<div id="utterances_thread" data-utterances-repo="hummat/hummat.github.io" data-utterances-issue-term="pathname" data-utterances-label="comments" data-utterances-theme="preferred-color-scheme"></div>',
+      commentsFixtureHtml(),
   });
   Object.defineProperty(dom.window.document, "readyState", {
     configurable: true,
@@ -34,12 +48,74 @@ test("consent banner loads analytics and utterances only after accept", async ()
   const gaScript = dom.window.document.getElementById("ga4-loader");
   const utterancesScript = dom.window.document.getElementById("utterances-embed-loader");
   assert.ok(gaScript);
-  assert.ok(utterancesScript);
+  assert.equal(utterancesScript, null);
   assert.match(gaScript.src, /googletagmanager\.com/);
-  assert.match(utterancesScript.src, /utteranc\.es\/client\.js/);
+  assert.equal(banner.hidden, true);
+});
+
+test("comments load only after explicit click and persist preference", async () => {
+  const dom = createDom({
+    bodyHtml: '<div id="cookie-consent-banner" hidden></div>' + commentsFixtureHtml(),
+  });
+  Object.defineProperty(dom.window.document, "readyState", {
+    configurable: true,
+    get: () => "complete",
+  });
+
+  runBrowserScript(dom, "assets/js/privacy-consent.js");
+  await flushMicrotasks();
+
+  const gate = dom.window.document.getElementById("comments-consent-gate");
+  const manage = dom.window.document.getElementById("comments-consent-manage");
+  const thread = dom.window.document.getElementById("utterances_thread");
+
+  assert.equal(gate.hidden, false);
+  assert.equal(manage.hidden, true);
+  assert.equal(thread.hidden, true);
+  assert.equal(dom.window.document.getElementById("utterances-embed-loader"), null);
+
+  const loadButton = gate.querySelector('[data-comments-action="accept"]');
+  loadButton.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+  await flushMicrotasks();
+
+  const utterancesScript = dom.window.document.getElementById("utterances-embed-loader");
+  assert.ok(utterancesScript);
+  assert.equal(dom.window.localStorage.getItem("hummat-comments-consent-v1"), "accepted");
+  assert.equal(gate.hidden, true);
+  assert.equal(manage.hidden, false);
+  assert.equal(thread.hidden, false);
   assert.equal(utterancesScript.getAttribute("repo"), "hummat/hummat.github.io");
   assert.equal(utterancesScript.getAttribute("issue-term"), "pathname");
   assert.equal(utterancesScript.getAttribute("label"), "comments");
   assert.equal(utterancesScript.getAttribute("theme"), "preferred-color-scheme");
-  assert.equal(banner.hidden, true);
+});
+
+test("comments revoke disables embed and updates preference", async () => {
+  const dom = createDom({
+    bodyHtml: '<div id="cookie-consent-banner" hidden></div>' + commentsFixtureHtml(),
+  });
+  Object.defineProperty(dom.window.document, "readyState", {
+    configurable: true,
+    get: () => "complete",
+  });
+  dom.window.localStorage.setItem("hummat-comments-consent-v1", "accepted");
+
+  runBrowserScript(dom, "assets/js/privacy-consent.js");
+  await flushMicrotasks();
+
+  const manage = dom.window.document.getElementById("comments-consent-manage");
+  const thread = dom.window.document.getElementById("utterances_thread");
+  const revokeButton = manage.querySelector('[data-comments-action="revoke"]');
+
+  assert.equal(manage.hidden, false);
+  assert.equal(thread.hidden, false);
+  assert.ok(dom.window.document.getElementById("utterances-embed-loader"));
+
+  revokeButton.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+  await flushMicrotasks();
+
+  assert.equal(dom.window.localStorage.getItem("hummat-comments-consent-v1"), "declined");
+  assert.equal(dom.window.document.getElementById("utterances-embed-loader"), null);
+  assert.equal(thread.hidden, true);
+  assert.equal(manage.hidden, true);
 });


### PR DESCRIPTION
## Summary

- Replace Disqus integration with utterances comments (GitHub Issues-based)
- Keep optional-service consent gating: comments and analytics load only after explicit accept
- Update comment template/config, consent loader logic/tests, and CSP allowlist accordingly
- Remove remaining Disqus-specific include and references in active architecture docs

Closes: #22

## Type of Change

- [ ] Content fix (typo, broken link, factual error)
- [ ] New post
- [x] Site improvement (layout, styling, functionality)
- [ ] Other

## Checklist

- [x] PR targets `netlify` branch (not `main`)
- [ ] Tested locally with `bundle exec jekyll serve`
- [x] Site builds without errors (`bundle exec jekyll build`)
- [ ] Screenshots attached (for visual changes)

## Verification

- `npm run test:js` ✅
- `npm run lint:js` ✅
- `npm run lint:md` ✅
- `npm run format:check` ✅
- `bundle exec jekyll build` ✅
- `npm run test:html` ✅

## Note

This uses **utterances** now because giscus is not yet installed on the repository. Once giscus app/category setup is complete, migration to giscus can be done in a follow-up PR with low risk.